### PR TITLE
Add CI build test for Datakit

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,0 +1,5 @@
+FROM ubuntu:latest
+RUN apt-get update && apt-get install -y docker.io --no-install-recommends
+VOLUME /mnt/datakit:/db
+ADD ci.sh build.sh ./
+CMD ./ci.sh

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash -eux
+docker build /db/snapshots/$1/ro

--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -1,0 +1,6 @@
+#!/bin/bash -eux
+while read HASH; do
+  echo Testing $HASH...
+  ./build.sh $HASH || echo '*** BUILD FAILED ***'
+  echo Waiting for next update...
+done < /db/branch/master/head.live


### PR DESCRIPTION
This uses Datakit to test building itself. Run the CI with:

```
docker run -d --name datakit-ci -v /mnt/datakit:/db -v /var/run/docker.sock:/var/run/docker.sock nuc1.local/admin/datakit-ci
```

Currently, it correctly detects that the build is broken.
