### PR TITLE
CI: commit build results

### DIFF
--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -1,6 +1,20 @@
 #!/bin/bash -eux
 while read HASH; do
   echo Testing $HASH...
-  ./build.sh $HASH || echo '*** BUILD FAILED ***'
+  # Create branch for the result
+  RESULT_BRANCH="/db/branch/ci-of-$HASH"
+  mkdir "$RESULT_BRANCH" || echo Branch already exists
+  if [ -f "$RESULT_BRANCH/ro/log" ]; then
+    echo Already built this commit... skipping
+  else
+    # Base the result branch on the source commit
+    echo $HASH > "$RESULT_BRANCH/fast-forward"
+    TRANS="$RESULT_BRANCH/transactions/log"
+    # Do the build, writing the log to a transaction
+    mkdir "$TRANS"
+    echo 'BUILD FAILED' > "$TRANS/msg"
+    ((./build.sh $HASH && echo PASSED > "$TRANS/msg") || echo '*** BUILD FAILED ***') 2>&1 | tee "$TRANS/rw/log"
+    echo commit > "$TRANS/ctl"
+  fi
   echo Waiting for next update...
 done < /db/branch/master/head.live

--- a/ci/push.sh
+++ b/ci/push.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -eux
+HOST=nuc1.local
+SSH_LOGIN=user@$HOST
+docker build -t $HOST/admin/datakit-ci .
+docker push $HOST/admin/datakit-ci
+ssh $SSH_LOGIN docker pull $HOST/admin/datakit-ci
+ssh $SSH_LOGIN docker rm -f datakit-ci
+ssh $SSH_LOGIN docker run -d --name datakit-ci -v /mnt/datakit:/db -v /var/run/docker.sock:/var/run/docker.sock $HOST/admin/datakit-ci
+ssh $SSH_LOGIN docker attach --sig-proxy=false datakit-ci


### PR DESCRIPTION
The CI script now creates a new branch (`ci-of-$HASH`) for each build,
whose parent is the source commit and which adds the log output of
building it. The commit message says whether it passed or failed.

You can `git fetch ci` to pull in all the logs and view them locally.
`gitk -all` will show the build results as branches from the source
commits.

If the results branch already exists it will not rebuild.
