### PR TITLE
Clean up I9p_tree API

### DIFF
--- a/src/i9p/i9p_tree.mli
+++ b/src/i9p/i9p_tree.mli
@@ -20,57 +20,65 @@ module type S = sig
   type store
   (** The type for Irmin stores. *)
 
-  type file
-  (** The type for file contents. *)
+  module File : sig
+    type t
+    (** The type for file contents. *)
+
+    val content : t -> string Lwt.t
+
+    val equal : t -> t -> bool
+    (** Quick equality check (compares hashes). *)
+
+    val pp_hash : Format.formatter -> t -> unit
+  end
 
   type repo
   (** The type for Irmin repositories. *)
 
-  type dir
-  (** An immutable directory node.
-      Note: normally we treat an empty directory as an error, but we do allow it
-      for the root. *)
+  module Dir : sig
+    type t
+    (** An immutable directory node.
+        Note: normally we treat an empty directory as an error, but we do allow it
+        for the root. *)
 
-  val empty : repo -> dir
+    type hash
+    (** The type for directory IDs (hashes). *)
 
-  val snapshot : store -> dir Lwt.t
+    val empty : repo -> t
+
+    val ty : t -> leaf -> [`File | `Directory | `None] Lwt.t
+    (** Check the type of a path. *)
+
+    val node : t -> path -> [`File of File.t | `Directory of t | `None ] Lwt.t
+    (** Look up an item by path. *)
+
+    val get : t -> path -> t option Lwt.t
+    (** Look up a sub-directory node. *)
+
+    val ls : t -> ([`File | `Directory] * leaf) list Lwt.t
+    (** List the contents of a directory with the type of each item. *)
+
+    val equal : t -> t -> bool
+    (** Quick equality check (compares hashes). *)
+
+    val of_hash : repo -> hash option -> t
+    (** [of_hash repo h] is the directory whose hash is [h] in
+        [repo]. *)
+
+    val hash : t -> hash option
+    (** [hash dir] is the [dir]'s hash. *)
+
+    val repo : t -> repo
+    (** [repo dir] is the repository in which [dir] lives. *)
+
+  end
+
+  val snapshot : store -> Dir.t Lwt.t
   (** Convert a branch, which may update while we read it, to a fixed directory
       by reading its current root. *)
-
-  val ty : dir -> leaf -> [`File | `Directory | `None] Lwt.t
-  (** Check the type of a path. *)
-
-  val node : dir -> path -> [`File of file | `Directory of dir | `None ] Lwt.t
-  (** Look up an item by path. *)
-
-  val get_dir : dir -> path -> dir option Lwt.t
-  (** Look up a sub-directory node. *)
-
-  val ls : dir -> ([`File | `Directory] * leaf) list Lwt.t
-  (** List the contents of a directory with the type of each item. *)
-
-  val equal : dir -> dir -> bool
-  (** Quick equality check (compared hashes). *)
-
-  val repo : dir -> repo
-  (** [repo dir] is the repository in which [dir] lives. *)
-
-  (** {1 Directory IDs} *)
-
-  type hash
-  (** The type for directory IDs (hashes). *)
-
-  val of_dir_hash : repo -> hash option -> dir
-  (** [of_dir_hash repo h] is the directory whose hash is [h] in
-      [repo]. *)
-
-  val hash : dir -> hash option
-  (** [hash dir] is the [dir]'s hash. *)
-
 end
 
 module Make (Store: STORE):
   S with type store = Store.t
-     and type file = Store.Private.Node.Val.contents
      and type repo = Store.Repo.t
-     and type hash = Store.Private.Node.Key.t
+     and type Dir.hash = Store.Private.Node.Key.t


### PR DESCRIPTION
- Add `Dir` and `File` sub-modules to group operations.
- Add `File.content` for reading a file.
- Add `File.equal` for quick (hash-based) equality tests.
- Add `File.pp_hash` to format the hash.
- Remove `string_of_leaf` hack.

This should make it possible to use other representations of files in
future (e.g. a blob in memory that is hashed lazily).
