### PR TITLE
Replace Irmin.View with I9p_rw

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -25,7 +25,7 @@ Library fs9p
 Library i9p
   Path:            src/i9p/
   Findlibname:     i9p
-  InternalModules: I9p_merge
+  InternalModules: I9p_merge, I9p_rw
   Modules:         I9p, I9p_tree, I9p_remote
   BuildDepends:    lwt, irmin, rresult, vfs, astring
 

--- a/src/fs9p/fs9p_error.ml
+++ b/src/fs9p/fs9p_error.ml
@@ -11,6 +11,7 @@ let error ?(errno=0l) fmt =
 
 let enoent = error "No such file or directory"
 let eisdir = error "Is a directory"
+let enotdir = error "Is not a directory"
 let ero = error "Read-only file"
 let eperm = error "Operation not permitted"
 
@@ -19,6 +20,7 @@ let of_error x =
   match x with
   | Noent          -> enoent
   | Isdir          -> eisdir
+  | Notdir         -> enotdir
   | Read_only_file -> ero
   | Perm           -> eperm
   | Other err      -> error ?errno:err.errno "%s" err.descr

--- a/src/i9p/i9p_merge.ml
+++ b/src/i9p/i9p_merge.ml
@@ -1,32 +1,32 @@
+open Astring
 open Lwt.Infix
 
 module PathSet = Set.Make(Irmin.Path.String_list)
 
+module type RW = sig
+  type t
+  val update_force : t -> I9p_tree.path -> string -> Cstruct.t -> unit Lwt.t
+  val remove_force : t -> I9p_tree.path -> string -> unit Lwt.t
+end
+
 module Make
     (Store : I9p_tree.STORE)
-    (View : Irmin.VIEW with type db = Store.t
-                        and type key = string list
-                        and type value = string)
+    (RW : RW)
 = struct
-  module LeafMap = Map.Make(String)
   module Tree = I9p_tree.Make(Store)
-
-  let as_map =
-    List.fold_left (fun acc (ty, leaf) ->
-        LeafMap.add leaf ty acc
-      ) LeafMap.empty
 
   let as_file = function
     | `File f -> Tree.File.content f >|= fun c -> Some c
     | `Directory _ | `None -> Lwt.return None
 
-  let merge_file = Irmin.Merge.(option (module Tc.String) string)
+  let merge_cstruct = Irmin.Merge.default (module Tc.Cstruct)
+  let merge_file = Irmin.Merge.option (module Tc.Cstruct) merge_cstruct
 
   let merge ~ours ~theirs ~base result =
     let conflicts = ref PathSet.empty in
-    let note_conflict path msg =
-      conflicts := !conflicts |> PathSet.add path;
-      View.update result path (Printf.sprintf "** Conflict **\n%s\n" msg) in
+    let note_conflict path leaf msg =
+      conflicts := !conflicts |> PathSet.add (Irmin.Path.String_list.rcons path leaf);
+      RW.update_force result path leaf (Cstruct.of_string (Printf.sprintf "** Conflict **\n%s\n" msg)) in
     let repo = Store.repo ours in
     let empty = Tree.Dir.empty repo in
     let as_dir = function
@@ -34,39 +34,41 @@ module Make
       | `File _ -> empty
       | `None -> empty in
     let rec merge_dir ~ours ~theirs ~base (path : string list) =
-      Tree.Dir.ls ours >|= as_map >>= fun our_files ->
-      Tree.Dir.ls theirs >|= as_map >>= fun their_files ->
+      Tree.Dir.map ours >>= fun our_files ->
+      Tree.Dir.map theirs >>= fun their_files ->
+      (* Types tells us the type the result will have, if successful, or [`Conflict] if we
+         know it won't work. *)
       let types =
-        LeafMap.merge (fun _leaf our_ty their_ty ->
-            match our_ty, their_ty with
-            | Some `Directory, Some `Directory -> Some `Directory
-            | Some `File, Some `File -> Some `File
+        String.Map.merge (fun _leaf ours theirs ->
+            match ours, theirs with
+            | Some (`Directory _), Some (`Directory _) -> Some `Directory
+            | Some (`File _), Some (`File _) -> Some `File
             | Some _, Some _ -> Some `Conflict
-            | Some `File, _ | _, Some `File -> Some `File
-            | Some `Directory, _ | _, Some `Directory -> Some `Directory
+            | Some (`File _), None | None, Some (`File _) -> Some `File
+            | Some (`Directory _), None | None, Some (`Directory _) -> Some `Directory
             | None, None -> assert false
           ) our_files their_files in
-      LeafMap.bindings types |> Lwt_list.iter_s (fun (leaf, ty) ->
-          let path = Irmin.Path.String_list.rcons path leaf in
+      String.Map.bindings types |> Lwt_list.iter_s (fun (leaf, ty) ->
+          let sub_path = Irmin.Path.String_list.rcons path leaf in
           match ty with
-          | `Conflict -> note_conflict path "File vs dir"
+          | `Conflict -> note_conflict path leaf "File vs dir"
           | `Directory ->
-            Tree.Dir.node ours [leaf] >|= as_dir >>= fun ours ->
-            Tree.Dir.node theirs [leaf] >|= as_dir >>= fun theirs ->
-            Tree.Dir.node base [leaf] >|= as_dir >>= fun base ->
-            merge_dir ~ours ~theirs ~base path
+            Tree.Dir.lookup ours leaf >|= as_dir >>= fun ours ->
+            Tree.Dir.lookup theirs leaf >|= as_dir >>= fun theirs ->
+            Tree.Dir.lookup base leaf >|= as_dir >>= fun base ->
+            merge_dir ~ours ~theirs ~base sub_path
           | `File ->
-            Tree.Dir.node ours [leaf] >>= as_file >>= fun ours ->
-            Tree.Dir.node theirs [leaf] >>= as_file >>= fun theirs ->
+            Tree.Dir.lookup ours leaf >>= as_file >>= fun ours ->
+            Tree.Dir.lookup theirs leaf >>= as_file >>= fun theirs ->
             let old () =
-              Tree.Dir.node base [leaf] >>= fun hash ->
+              Tree.Dir.lookup base leaf >>= fun hash ->
               as_file hash >|= fun f ->
               `Ok (Some f) in
             merge_file ~old ours theirs >>= function
-            | `Ok (Some x) -> View.update result path x
-            | `Ok None -> View.remove result path
-            | `Conflict "default" -> note_conflict path "Changed on both branches"
-            | `Conflict x -> note_conflict path x
+            | `Ok (Some x) -> RW.update_force result path leaf x
+            | `Ok None -> RW.remove_force result path leaf
+            | `Conflict "default" -> note_conflict path leaf "Changed on both branches"
+            | `Conflict x -> note_conflict path leaf x
         ) in
     Tree.snapshot ours >>= fun ours ->
     Tree.snapshot theirs >>= fun theirs ->

--- a/src/i9p/i9p_merge.mli
+++ b/src/i9p/i9p_merge.mli
@@ -1,16 +1,17 @@
 module PathSet : Set.S with type elt = Irmin.Path.String_list.t
 
-module Make
-    (Store : I9p_tree.STORE)
-    (View : Irmin.VIEW with type db = Store.t
-                        and type key = string list
-                        and type value = string) :
-sig
+module type RW = sig
+  type t
+  val update_force : t -> I9p_tree.path -> string -> Cstruct.t -> unit Lwt.t
+  val remove_force : t -> I9p_tree.path -> string -> unit Lwt.t
+end
+
+module Make (Store : I9p_tree.STORE) (RW : RW) : sig
   val merge :
     ours:Store.t ->
     theirs:Store.t ->
     base:Store.t option ->
-    View.t -> PathSet.t Lwt.t
+    RW.t -> PathSet.t Lwt.t
     (** [merge ~ours ~theirs ~base result] updates [result] (which initially is a
         copy of [ours]) to our best attempt at a merge.
         Returns the set of paths with conflicts. *)

--- a/src/i9p/i9p_rw.ml
+++ b/src/i9p/i9p_rw.ml
@@ -1,0 +1,80 @@
+open Lwt.Infix
+open Result
+
+let ( >>*= ) x f =
+  x >>= function
+  | Ok y -> f y
+  | Error _ as e -> Lwt.return e
+
+type impossible
+let doesnt_fail = function
+  | Ok x -> x
+  | Error (_:impossible) -> assert false
+
+module Make (Tree : I9p_tree.S) = struct
+  type t = {
+    mutable root : Tree.Dir.t;
+    mutex : Lwt_mutex.t;
+  }
+
+  let of_dir root = {
+    root;
+    mutex = Lwt_mutex.create ();
+  }
+
+  let root t = t.root
+
+  (* Walk to [t.root/path] and process the resulting directory with [fn dir], then update
+     all the parents back to the root. *)
+  let update_dir ~file_on_path t path fn =
+    Lwt_mutex.with_lock t.mutex @@ fun () ->
+    let rec aux base path =
+      match Irmin.Path.String_list.decons path with
+      | None -> fn base
+      | Some (p, ps) ->
+          begin Tree.Dir.lookup base p >>= function
+          | `None ->
+              aux (Tree.Dir.empty (Tree.Dir.repo base)) ps
+          | `Directory subdir ->
+              aux subdir ps
+          | `File f ->
+              file_on_path f >>*= fun () ->
+              aux (Tree.Dir.empty (Tree.Dir.repo base)) ps
+          end >>*= fun new_subdir ->
+          Tree.Dir.with_child base p (`Directory new_subdir) >|= fun x ->
+          Ok x
+    in
+    aux t.root path >>*= fun new_root ->
+    t.root <- new_root;
+    Lwt.return (Ok ())
+
+  let err_not_a_directory (_ : Tree.File.t) =
+    Lwt.return (Error `Not_a_directory)
+
+  let replace_with_dir (_ : Tree.File.t) =
+    Lwt.return (Ok ())
+
+  let update t path leaf value =
+    let repo = Tree.Dir.repo t.root in
+    update_dir ~file_on_path:err_not_a_directory t path @@ fun dir ->
+    Tree.Dir.lookup dir leaf >>= function
+    | `Directory _ -> Lwt.return (Error `Is_a_directory)
+    | `File _ | `None ->
+    Tree.Dir.with_child dir leaf (`File (Tree.File.of_data repo value)) >|= fun new_dir -> Ok new_dir
+
+  let remove t path leaf =
+    update_dir ~file_on_path:err_not_a_directory t path @@ fun dir ->
+    Tree.Dir.without_child dir leaf >|= fun new_dir -> Ok new_dir
+
+  let update_force t path leaf value =
+    let repo = Tree.Dir.repo t.root in
+    update_dir ~file_on_path:replace_with_dir t path (fun dir ->
+      Tree.Dir.with_child dir leaf (`File (Tree.File.of_data repo value)) >|= fun new_dir -> Ok new_dir
+    ) >|= doesnt_fail
+
+  let remove_force t path leaf =
+    update_dir ~file_on_path:replace_with_dir t path (fun dir ->
+      Tree.Dir.without_child dir leaf >|= fun new_dir -> Ok new_dir
+    ) >|= doesnt_fail
+
+end

--- a/src/i9p/i9p_rw.mli
+++ b/src/i9p/i9p_rw.mli
@@ -1,0 +1,27 @@
+open Result
+
+module Make (Tree : I9p_tree.S) : sig
+  type t
+
+  val of_dir : Tree.Dir.t -> t
+
+  val root : t -> Tree.Dir.t
+
+  val update : t -> I9p_tree.path -> string -> Cstruct.t -> (unit, [`Is_a_directory | `Not_a_directory]) result Lwt.t
+  (** [update t dir leaf data] makes [dir/leaf] be the file [data].
+      Missing directories may be created. If [dir/leaf] is a file then it is overwritten.
+      Fails if [dir/leaf] is a directory, or any component of [dir] is not a directory. *)
+
+  val remove : t -> I9p_tree.path -> string -> (unit, [`Not_a_directory]) result Lwt.t
+  (** [remove t dir leaf] ensures that [dir/leaf] does not exist.
+      Fails if any component of [dir] is not a directory. *)
+
+  val update_force : t -> I9p_tree.path -> string -> Cstruct.t -> unit Lwt.t
+  (** [update_force t path leaf value] ensures that [path/leaf] is a file containing [value].
+      Any existing files and directories that are in the way are destroyed. *)
+
+  val remove_force : t -> I9p_tree.path -> string -> unit Lwt.t
+  (** [remove_force t path leaf] ensures that [path/leaf] does not exist.
+      This will delete the entire subtree if [path/leaf] is a directory.
+      It does nothing if  [path/leaf] does not exist. *)
+end

--- a/src/vfs/vfs.ml
+++ b/src/vfs/vfs.ml
@@ -12,12 +12,14 @@ module Error = struct
   type t =
     | Noent
     | Isdir
+    | Notdir
     | Read_only_file
     | Perm
     | Other of err
 
   let no_entry = Error Noent
   let is_dir = Error Isdir
+  let not_dir = Error Notdir
   let read_only_file = Error Read_only_file
   let perm = Error Perm
 
@@ -122,6 +124,7 @@ module File = struct
          the application. To Linux, two "" in a row means end-of-file.
          Other systems will probably interpret a single "" as end-of-file.
          Oh well. *)
+      (* TODO: prevent concurrent reads/writes *)
       let read ~offset ~count =
         if offset <> !current_offset then err_stream_seek
         else if !need_flush then (

--- a/src/vfs/vfs.mli
+++ b/src/vfs/vfs.mli
@@ -17,6 +17,7 @@ module Error: sig
   type t =
     | Noent                                    (** No such file or directory. *)
     | Isdir                                     (** The entry is a directory. *)
+    | Notdir                                (** The entry is not a directory. *)
     | Read_only_file                               (** The file is read-only. *)
     | Perm                                (** The operation is not permitted. *)
     | Other of err                                (** Generic error function. *)
@@ -32,6 +33,9 @@ module Error: sig
 
   val is_dir: ('a, t) result
   (** [is_dir] is [Error Isdir]. *)
+
+  val not_dir: ('a, t) result
+  (** [not_dir] is [Error Notdir]. *)
 
   val read_only_file: ('a, t) result
   (** [read_only_file] is [Error Read_only_file]. *)

--- a/tests/test_utils.ml
+++ b/tests/test_utils.ml
@@ -79,6 +79,9 @@ let () =
 module Store = Irmin_git.Memory(Ir_io.Sync)(Ir_io.Zlib)
     (Irmin.Contents.String)(Irmin.Ref.String)(Irmin.Hash.SHA1)
 
+module Tree = I9p_tree.Make(Store)
+module RW = I9p_rw.Make(Tree)
+
 module Server = Fs9p.Make(Test_flow)
 module Filesystem = I9p.Make(Store)
 


### PR DESCRIPTION
I9p_rw simply holds a mutable reference to an I9p_tree.Dir (the root)
and provides convenient functions to update it. I9p_tree has been
extended to support both in-memory and on-disk files and directories.

Some advantages:
- Unlike Irmin.View, we do not keep a log of actions performed on the
  transaction. Keeping this was causing us to run out of memory.
- We can get a snapshot of a view cheaply, by simply taking a reference
  to the current root node (which is immutable). This may fix #16.

The stream watchers had to change slightly because `hash` is now async
(might need to flush to disk), although in fact this can't happen
because we don't allow watching views.

Signed-off-by: Thomas Leonard thomas.leonard@docker.com
