### PR TITLE
Ensure inode numbers are stable

### DIFF
--- a/src/vfs/vfs.mli
+++ b/src/vfs/vfs.mli
@@ -263,4 +263,8 @@ end and Inode: sig
   val kind: t -> kind
   (** [kind t] is [t]'s kind. *)
 
+  val ino: t -> int64
+  (** [ino t] is a unique "inode number" for the file. If two files have the
+      same inode number, then they are the same file. *)
+
 end


### PR DESCRIPTION
When the Vfs code got split out from the 9p support, the unique inode
ID wasn't included. Instead, the 9p support started minting a new ID
each time it was asked for one. This meant that clients saw a new inode
number each time they asked for it. This confused cp at least, which
checks that the inode number is the same before and after opening the
file.

Fixes #52.

Signed-off-by: Thomas Leonard thomas.leonard@docker.com
