### PR TITLE
Add an Dockerfile.github to build Datakit with Github bindings

### DIFF
--- a/Dockerfile.github
+++ b/Dockerfile.github
@@ -1,0 +1,27 @@
+FROM ocaml/opam:alpine
+
+RUN opam depext lwt ssl &&  opam install lwt alcotest
+
+RUN opam pin add github --dev
+RUN opam pin add protocol-9p --dev
+
+COPY opam /home/opam/src/datakit/opam
+RUN opam pin add datakit.dev /home/opam/src/datakit -n
+RUN opam depext datakit ssl github && \
+    opam install ssl github datakit --deps # Install datakit deps
+
+COPY . /home/opam/src/datakit/
+RUN sudo chown -R opam.nogroup /home/opam/src
+WORKDIR /home/opam/src/datakit
+
+ENV GITHUB=enable
+RUN opam config exec -- make && make test && make install
+
+EXPOSE 5640
+
+RUN sudo mkdir /data && sudo chown opam.nogroup /data && chmod 700 /data && \
+    sudo cp /home/opam/.opam/system/bin/datakit /usr/bin/datakit
+
+ENV COHTTP_DEBUG 10
+
+CMD ["/usr/bin/datakit", "--url=tcp://0.0.0.0:5640", "--git=/data", "--verbose=debug"]

--- a/scripts/start-datakit.sh
+++ b/scripts/start-datakit.sh
@@ -2,9 +2,17 @@
 
 set -exu
 
+DATAKIT_GITHUB=${DATAKIT_GITHUB=0}
+
+if [ "$DATAKIT_GITHUB" != 0 ]; then
+    DOCKERFILE=Dockerfile.github
+else
+    DOCKERFILE=Dockerfile
+fi
+
 REPO_ROOT=$(git rev-parse --show-toplevel)
 
-docker build -t datakit ${REPO_ROOT}
+docker build -t datakit -f ${DOCKERFILE} ${REPO_ROOT}
 docker rm -f db || echo skip
 docker run -p 5650:5640 --name=db --rm \
   -v ${HOME}/.github:/home/opam/.github \


### PR DESCRIPTION
This is disabled by default to avoid making com.docker.db (shipped with Pinata)
depend on libssl or libgmp.

Signed-off-by: Thomas Gazagnaire thomas@gazagnaire.org
