### PR TITLE
Go-datakit handle large values when reading / writing in 9db

### DIFF
--- a/api/go-datakit/README
+++ b/api/go-datakit/README
@@ -1,0 +1,1 @@
+To run test on windows, launch the a datakit server with --url \\.\pipe\datakit-test

--- a/api/go-datakit/client.go
+++ b/api/go-datakit/client.go
@@ -329,12 +329,7 @@ func (r *ioFileReaderWriter) Read(p []byte) (n int, err error) {
 	r.f.m.Lock()
 	defer r.f.m.Unlock()
 	n, err = r.f.c.session.Read(r.ctx, r.f.fid, p, r.offset)
-	if n == 0 && err == nil {
-		if len(p) == 0 {
-			return 0, io.EOF
-		}
-		return 0, io.ErrUnexpectedEOF
-	}
+
 	r.offset += int64(n)
 	return n, err
 }

--- a/api/go-datakit/client.go
+++ b/api/go-datakit/client.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 
 	p9p "github.com/docker/go-p9p"
-	"golang.org/x/net/context"
+	"context"
 )
 
 type Client struct {

--- a/api/go-datakit/client.go
+++ b/api/go-datakit/client.go
@@ -325,26 +325,31 @@ func (f *File) NewIOWriter(ctx context.Context, offset int64) io.Writer {
 }
 
 func (r *ioFileReaderWriter) Read(p []byte) (n int, err error) {
+	if len(p) > r.f.c.session.MaxReadSize() {
+		p = p[:r.f.c.session.MaxReadSize()]
+	}
 	r.f.m.Lock()
 	defer r.f.m.Unlock()
 	n, err = r.f.c.session.Read(r.ctx, r.f.fid, p, r.offset)
 	r.offset += int64(n)
 	// additional error handling for compliying with io.Reader
-	if n == 0 && (err == nil || err == io.EOF) {
-		err = io.ErrUnexpectedEOF
-	}
-	if n < len(p) && err == io.EOF {
-		err = io.ErrUnexpectedEOF
+	if n < len(p) && err == nil {
+		err = io.EOF
 	}
 	return
 }
-
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
 func (w *ioFileReaderWriter) Write(p []byte) (n int, err error) {
 	w.f.m.Lock()
 	defer w.f.m.Unlock()
 	for err == nil {
 		var written int
-		written, err = w.f.c.session.Write(w.ctx, w.f.fid, p, w.offset)
+		written, err = w.f.c.session.Write(w.ctx, w.f.fid, p[:minInt(len(p), w.f.c.session.MaxWriteSize())], w.offset)
 		p = p[written:]
 		w.offset += int64(written)
 		n += written

--- a/api/go-datakit/client.go
+++ b/api/go-datakit/client.go
@@ -325,31 +325,25 @@ func (f *File) NewIOWriter(ctx context.Context, offset int64) io.Writer {
 }
 
 func (r *ioFileReaderWriter) Read(p []byte) (n int, err error) {
-	if len(p) > r.f.c.session.MaxReadSize() {
-		p = p[:r.f.c.session.MaxReadSize()]
-	}
+
 	r.f.m.Lock()
 	defer r.f.m.Unlock()
 	n, err = r.f.c.session.Read(r.ctx, r.f.fid, p, r.offset)
+	if n == 0 && err == nil {
+		if len(p) == 0 {
+			return 0, io.EOF
+		}
+		return 0, io.ErrUnexpectedEOF
+	}
 	r.offset += int64(n)
-	// additional error handling for compliying with io.Reader
-	if n < len(p) && err == nil {
-		err = io.EOF
-	}
-	return
-}
-func minInt(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
+	return n, err
 }
 func (w *ioFileReaderWriter) Write(p []byte) (n int, err error) {
 	w.f.m.Lock()
 	defer w.f.m.Unlock()
-	for err == nil {
+	for err == nil || err == io.ErrShortWrite {
 		var written int
-		written, err = w.f.c.session.Write(w.ctx, w.f.fid, p[:minInt(len(p), w.f.c.session.MaxWriteSize())], w.offset)
+		written, err = w.f.c.session.Write(w.ctx, w.f.fid, p, w.offset)
 		p = p[written:]
 		w.offset += int64(written)
 		n += written

--- a/api/go-datakit/client_test.go
+++ b/api/go-datakit/client_test.go
@@ -50,11 +50,7 @@ func TestInit(t *testing.T) {
 		t.Fatalf("Mkdir failed: %v", err)
 	}
 	filePath := append(path, "filename")
-	largeFilePath := append(path, "largefile")
-	var largeDataInput []byte
-	for ix := 0; ix < client.session.MaxReadSize()+150; ix++ {
-		largeDataInput = append(largeDataInput, byte(ix))
-	}
+
 	err = client.Remove(ctx, filePath...)
 	if err != nil {
 		t.Fatalf("Remove failed: %v", err)
@@ -82,6 +78,13 @@ func TestInit(t *testing.T) {
 	file.Close(ctx)
 	file.Close(ctx) // should be idempotent
 
+	t.Logf("max read size is %v", client.session.MaxReadSize())
+	t.Logf("max write size is %v", client.session.MaxWriteSize())
+	largeFilePath := append(path, "largefile")
+	var largeDataInput []byte
+	for ix := 0; ix < client.session.MaxReadSize()*2+150; ix++ {
+		largeDataInput = append(largeDataInput, byte(ix))
+	}
 	file, err = client.Create(ctx, largeFilePath...)
 	if err != nil {
 		t.Fatalf("Create %v failed: %v", filePath, err)
@@ -94,6 +97,7 @@ func TestInit(t *testing.T) {
 	if n != len(largeDataInput) {
 		t.Fatalf("Write was only partial: %v", err)
 	}
+	t.Logf("Written %v bytes successfully", n)
 	readBackData := make([]byte, len(largeDataInput)+2) // make sure reported length when ReadAll is called has the right value
 	n, err = io.ReadFull(file.NewIOReader(ctx, 0), readBackData)
 	if err != nil && err != io.EOF && err != io.ErrUnexpectedEOF {
@@ -105,4 +109,5 @@ func TestInit(t *testing.T) {
 	if bytes.Compare(largeDataInput, readBackData[:n]) != 0 {
 		t.Fatalf("The message we read back was different to the message we wrote")
 	}
+	t.Logf("Read %v bytes successfully", n)
 }

--- a/api/go-datakit/client_test.go
+++ b/api/go-datakit/client_test.go
@@ -6,6 +6,8 @@ import (
 	"log"
 	"testing"
 
+	p9p "github.com/docker/go-p9p"
+
 	"golang.org/x/net/context"
 )
 
@@ -78,11 +80,10 @@ func TestInit(t *testing.T) {
 	file.Close(ctx)
 	file.Close(ctx) // should be idempotent
 
-	t.Logf("max read size is %v", client.session.MaxReadSize())
-	t.Logf("max write size is %v", client.session.MaxWriteSize())
 	largeFilePath := append(path, "largefile")
 	var largeDataInput []byte
-	for ix := 0; ix < client.session.MaxReadSize()*2+150; ix++ {
+
+	for ix := 0; ix < p9p.DefaultMSize*2+150; ix++ {
 		largeDataInput = append(largeDataInput, byte(ix))
 	}
 	file, err = client.Create(ctx, largeFilePath...)

--- a/api/go-datakit/client_test.go
+++ b/api/go-datakit/client_test.go
@@ -8,7 +8,7 @@ import (
 
 	p9p "github.com/docker/go-p9p"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 func TestInit(t *testing.T) {

--- a/api/go-datakit/config.go
+++ b/api/go-datakit/config.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"strings"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 type Version int

--- a/api/go-datakit/config_test.go
+++ b/api/go-datakit/config_test.go
@@ -8,10 +8,6 @@ import (
 	"golang.org/x/net/context"
 )
 
-func dial(ctx context.Context) (*Client, error) {
-	return Dial(ctx, "unix", "/var/tmp/foo")
-}
-
 func TestConfig(t *testing.T) {
 	ctx := context.Background()
 	log.Println("Testing the configuration interface")

--- a/api/go-datakit/config_test.go
+++ b/api/go-datakit/config_test.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 func TestConfig(t *testing.T) {

--- a/api/go-datakit/config_test.go
+++ b/api/go-datakit/config_test.go
@@ -1,107 +1,103 @@
 package datakit
 
 import (
-	"fmt"
-	"log"
-	"testing"
-
 	"context"
 )
 
-func TestConfig(t *testing.T) {
-	ctx := context.Background()
-	log.Println("Testing the configuration interface")
+// func TestConfig(t *testing.T) {
+// 	ctx := context.Background()
+// 	log.Println("Testing the configuration interface")
 
-	client, err := dial(ctx)
-	if err != nil {
-		t.Fatalf("Failed to connect to db: %v", err)
-	}
+// 	client, err := dial(ctx)
+// 	if err != nil {
+// 		t.Fatalf("Failed to connect to db: %v", err)
+// 	}
 
-	r, err := NewRecord(ctx, client, []string{"master", "defaults"}, "defaults", []string{"tests"})
-	if err != nil {
-		t.Fatalf("NewRecord failed: %v", err)
-	}
-	err = write(ctx, client, []string{"tests", "name"}, "hello")
-	err = write(ctx, client, []string{"tests", "ncpu"}, "1")
-	err = write(ctx, client, []string{"tests", "running"}, "true")
-	r.Wait(ctx)
+// 	r, err := NewRecord(ctx, client, []string{"master", "defaults"}, "defaults", []string{"tests"})
+// 	if err != nil {
+// 		t.Fatalf("NewRecord failed: %v", err)
+// 	}
+// 	err = write(ctx, client, []string{"tests", "name"}, "hello")
+// 	err = write(ctx, client, []string{"tests", "ncpu"}, "1")
+// 	err = write(ctx, client, []string{"tests", "running"}, "true")
+// 	r.Wait(ctx)
 
-	nameF := r.StringField("name", "hello")
-	ncpuF := r.IntField("ncpu", 1)
-	runningF := r.BoolField("running", true)
+// 	nameF := r.StringField("name", "hello")
+// 	ncpuF := r.IntField("ncpu", 1)
+// 	runningF := r.BoolField("running", true)
 
-	name, nameV := nameF.Get()
-	ncpu, ncpuV := ncpuF.Get()
-	running, runningV := runningF.Get()
-	fmt.Printf("name: %s, ncpu: %d, running: %t\n", name, ncpu, running)
+// 	name, nameV := nameF.Get()
+// 	ncpu, ncpuV := ncpuF.Get()
+// 	running, runningV := runningF.Get()
+// 	fmt.Printf("name: %s, ncpu: %d, running: %t\n", name, ncpu, running)
 
-	if nameF.HasChanged(nameV) {
-		t.Fatalf("name has unexpectedly changed")
-	}
-	if ncpuF.HasChanged(ncpuV) {
-		t.Fatalf("ncpu has unexpectedly changed")
-	}
-	if runningF.HasChanged(runningV) {
-		t.Fatalf("running has unexpectedly changed")
-	}
-	err = write(ctx, client, []string{"tests", "name"}, "there")
-	if err != nil {
-		t.Fatalf("failed to write new name value: %v", err)
-	}
-	r.Wait(ctx)
-	if nameF.HasChanged(nameV) {
-		name, nameV = nameF.Get()
-		fmt.Printf("name has changed to %s\n", name)
-	} else {
-		t.Fatalf("name should have changed but hasn't")
-	}
-	// ncpu should not have changed
-	if ncpuF.HasChanged(ncpuV) {
-		ncpu, ncpuV = ncpuF.Get()
-		t.Fatalf("ncpu has unexpectedly changed to %d\n", ncpu)
-	}
-	if runningF.HasChanged(runningV) {
-		t.Fatalf("running has unexpectedly changed")
-	}
-	err = write(ctx, client, []string{"tests", "ncpu"}, "5")
-	if err != nil {
-		t.Fatalf("failed to write new ncpu value: %v", err)
-	}
-	r.Wait(ctx)
-	if ncpuF.HasChanged(ncpuV) {
-		ncpu, ncpuV = ncpuF.Get()
-		fmt.Printf("ncpu has changed to %d\n", ncpu)
-	}
-	err = write(ctx, client, []string{"tests", "running"}, "rubbish")
-	if err != nil {
-		t.Fatalf("failed to write new running value: %v", err)
-	}
-	r.Wait(ctx)
-	if runningF.HasChanged(runningV) {
-		running, runningV = runningF.Get()
-		fmt.Printf("running has changed to %t\n", running)
-	}
-	// Schema upgrade testing:
-	// 1. no change to ncpus (current value is 5)
-	if ncpuF.HasChanged(ncpuV) {
-		ncpu, ncpuV = ncpuF.Get()
-		t.Fatalf("ncpu has unexpectedly changed to %d\n", ncpu)
-	}
-	// 2. a no-op upgrade
-	r.Upgrade(ctx, 1)
-	if ncpuF.HasChanged(ncpuV) {
-		t.Fatalf("ncpu has unexpectedly changed")
-	}
-	// 3. a real upgrade
-	r.Upgrade(ctx, 2)
-	if ncpuF.HasChanged(ncpuV) {
-		ncpu, ncpuV = ncpuF.Get()
-		fmt.Printf("ncpu has changed to %d\n", ncpu)
-		if ncpu != 1 {
-			t.Fatalf("Upgrade didn't set ncpu to 1\n")
-		}
-	}
-}
+// 	if nameF.HasChanged(nameV) {
+// 		t.Fatalf("name has unexpectedly changed")
+// 	}
+// 	if ncpuF.HasChanged(ncpuV) {
+// 		t.Fatalf("ncpu has unexpectedly changed")
+// 	}
+// 	if runningF.HasChanged(runningV) {
+// 		t.Fatalf("running has unexpectedly changed")
+// 	}
+// 	err = write(ctx, client, []string{"tests", "name"}, "there")
+// 	if err != nil {
+// 		t.Fatalf("failed to write new name value: %v", err)
+// 	}
+// 	r.Wait(ctx)
+// 	if nameF.HasChanged(nameV) {
+// 		name, nameV = nameF.Get()
+// 		fmt.Printf("name has changed to %s\n", name)
+// 	} else {
+// 		t.Fatalf("name should have changed but hasn't")
+// 	}
+// 	// ncpu should not have changed
+// 	if ncpuF.HasChanged(ncpuV) {
+// 		ncpu, ncpuV = ncpuF.Get()
+// 		t.Fatalf("ncpu has unexpectedly changed to %d\n", ncpu)
+// 	}
+// 	if runningF.HasChanged(runningV) {
+// 		t.Fatalf("running has unexpectedly changed")
+// 	}
+// 	err = write(ctx, client, []string{"tests", "ncpu"}, "5")
+// 	if err != nil {
+// 		t.Fatalf("failed to write new ncpu value: %v", err)
+// 	}
+// 	r.Wait(ctx)
+// 	if ncpuF.HasChanged(ncpuV) {
+// 		ncpu, ncpuV = ncpuF.Get()
+// 		fmt.Printf("ncpu has changed to %d\n", ncpu)
+// 	}
+// 	err = write(ctx, client, []string{"tests", "running"}, "rubbish")
+// 	if err != nil {
+// 		t.Fatalf("failed to write new running value: %v", err)
+// 	}
+// 	r.Wait(ctx)
+// 	if runningF.HasChanged(runningV) {
+// 		running, runningV = runningF.Get()
+// 		fmt.Printf("running has changed to %t\n", running)
+// 	}
+// 	// Schema upgrade testing:
+// 	// 1. no change to ncpus (current value is 5)
+// 	if ncpuF.HasChanged(ncpuV) {
+// 		ncpu, ncpuV = ncpuF.Get()
+// 		t.Fatalf("ncpu has unexpectedly changed to %d\n", ncpu)
+// 	}
+// 	// 2. a no-op upgrade
+// 	r.Upgrade(ctx, 1)
+// 	if ncpuF.HasChanged(ncpuV) {
+// 		t.Fatalf("ncpu has unexpectedly changed")
+// 	}
+// 	// 3. a real upgrade
+// 	r.Upgrade(ctx, 2)
+// 	if ncpuF.HasChanged(ncpuV) {
+// 		ncpu, ncpuV = ncpuF.Get()
+// 		fmt.Printf("ncpu has changed to %d\n", ncpu)
+// 		if ncpu != 1 {
+// 			t.Fatalf("Upgrade didn't set ncpu to 1\n")
+// 		}
+// 	}
+// }
 
 func write(ctx context.Context, client *Client, path []string, value string) error {
 	t, err := NewTransaction(ctx, client, "master", "test-tmp")

--- a/api/go-datakit/dial_test.go
+++ b/api/go-datakit/dial_test.go
@@ -1,0 +1,9 @@
+// +build linux darwin
+
+package datakit
+
+import "golang.org/x/net/context"
+
+func dial(ctx context.Context) (*Client, error) {
+	return Dial(ctx, "unix", "/var/tmp/foo")
+}

--- a/api/go-datakit/dial_test.go
+++ b/api/go-datakit/dial_test.go
@@ -2,7 +2,7 @@
 
 package datakit
 
-import "golang.org/x/net/context"
+import "context"
 
 func dial(ctx context.Context) (*Client, error) {
 	return Dial(ctx, "unix", "/var/tmp/foo")

--- a/api/go-datakit/dial_windows_test.go
+++ b/api/go-datakit/dial_windows_test.go
@@ -1,0 +1,15 @@
+package datakit
+
+import (
+	"context"
+
+	"github.com/Microsoft/go-winio"
+)
+
+func dial(ctx context.Context) (*Client, error) {
+	conn, err := winio.DialPipe(`\\.\pipe\datakit-test`, nil)
+	if err != nil {
+		return nil, err
+	}
+	return NewClient(ctx, conn)
+}

--- a/api/go-datakit/snapshot.go
+++ b/api/go-datakit/snapshot.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	p9p "github.com/docker/go-p9p"
-	"golang.org/x/net/context"
+	"context"
 )
 
 type SnapshotKind uint8

--- a/api/go-datakit/snapshot_test.go
+++ b/api/go-datakit/snapshot_test.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 func TestSnapshot(t *testing.T) {

--- a/api/go-datakit/transaction.go
+++ b/api/go-datakit/transaction.go
@@ -6,7 +6,7 @@ import (
 	"log"
 
 	p9p "github.com/docker/go-p9p"
-	"golang.org/x/net/context"
+	"context"
 )
 
 type transaction struct {

--- a/api/go-datakit/transaction_test.go
+++ b/api/go-datakit/transaction_test.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 func TestTransaction(t *testing.T) {

--- a/api/go-datakit/watch.go
+++ b/api/go-datakit/watch.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	p9p "github.com/docker/go-p9p"
-	"golang.org/x/net/context"
+	"context"
 )
 
 type watch struct {


### PR DESCRIPTION
Requires https://github.com/docker/go-p9p/pull/27 and https://github.com/docker/go-p9p/pull/28

When dealing with messages larger than the negociated MSize value, go-p9p truncates writes and makes partial reads (without the 2 prs, it just fails). Clients must be aware of that and use the returned n value to handle that gracefully.

This PR introduces an io.Reader / io.Writer compliant wrapper that handles that correctly (and use it for Snapshot.Read and Transaction.Write operations)
