### PR TITLE
github: Add support for org hooks

### DIFF
--- a/bridge/github/datakit_github_api.ml
+++ b/bridge/github/datakit_github_api.ml
@@ -466,5 +466,6 @@ module Webhook = struct
   ]
 
   let watch t r = watch t ~events:default_events (of_repo r)
+  let watch_org t (o:Org.t) = watch_org t ~events:default_events (o :> string)
 
 end


### PR DESCRIPTION
This PR requires:

- https://github.com/mirage/ocaml-github/pull/180
- https://github.com/mirage/ocaml-github/pull/181
- https://github.com/dsheets/ocaml-github-hooks/pull/8

This is (yet) untested.

It tries to follow a simple design:
- to watch the organisation `foo`, add a file `foo/.monitor`
- if you monitor an organisation,  you will receive all the events for all the repositories of that organisation.
- you can add an org hook if you have either `webhook:w` or `org[foo]:w` capabilities
