### PR TITLE
Better error for invalid job names

### DIFF
--- a/ci/src/cI_config.mli
+++ b/ci/src/cI_config.mli
@@ -1,11 +1,10 @@
 open Datakit_github
-open Astring
 
 type test = string CI_term.t
 
 type project = {
   dashboards : CI_target.Set.t;
-  tests : CI_target.t -> test String.Map.t;
+  tests : CI_target.t -> test CI_utils.Job_map.t;
 }
 
 type t = private {

--- a/ci/src/cI_engine.mli
+++ b/ci/src/cI_engine.mli
@@ -1,5 +1,4 @@
 open Datakit_github
-open Astring
 open CI_utils
 
 type t
@@ -15,7 +14,7 @@ val create :
   web_ui:Uri.t ->
   ?canaries:CI_target.Set.t Repo.Map.t ->
   (unit -> DK.t Lwt.t) ->
-  (CI_target.t -> string CI_term.t String.Map.t) Repo.Map.t ->
+  (CI_target.t -> string CI_term.t Job_map.t) Repo.Map.t ->
   t
 (** [create ~web_ui connect projects] is a new DataKit CI that calls [connect] to connect to the database.
     Once [listen] has been called, it will handle CI for [projects].

--- a/ci/src/cI_history.mli
+++ b/ci/src/cI_history.mli
@@ -1,4 +1,3 @@
-open Astring
 open CI_utils
 
 type t
@@ -14,7 +13,7 @@ module State : sig
   val parents : t -> string list
   (** [parents t] is the list of hashes of [t]'s parent commits. *)
 
-  val jobs : t -> string CI_output.t String.Map.t
+  val jobs : t -> string CI_output.t Job_map.t
   (** [jobs t] returns the list of jobs and their outputs at [t]. *)
 
   val metadata_commit : t -> string option
@@ -35,7 +34,7 @@ val create : unit -> t
 
 val lookup : t -> DK.t -> CI_target.t -> target Lwt.t
 
-val record : target -> DK.t -> source_commit:string -> DK.Commit.t -> string CI_output.t String.Map.t -> unit Lwt.t
+val record : target -> DK.t -> source_commit:string -> DK.Commit.t -> string CI_output.t Job_map.t -> unit Lwt.t
 (** [record target dk ~source_commit input jobs] records the new output of each job in [jobs]
     as a new commit of [target], and records that it was calculated using metadata snapshot [input].
     The commit index of [source_commit] is updated to include the new result (for [builds_of_commit]). *)

--- a/ci/src/cI_term.ml
+++ b/ci/src/cI_term.ml
@@ -84,13 +84,13 @@ let pp_opt_descr f = function
 
 let ci_success_target_url ci target =
   ci_status ci target >>= function
-  | None -> pending "Waiting for %a status to appear" Ref.pp_name ci
-  | Some `Pending -> ci_descr ci target >>= pending "Waiting for %a to complete%a" Ref.pp_name ci pp_opt_descr
-  | Some `Failure -> ci_descr ci target >>= fail "%a failed%a" Ref.pp_name ci pp_opt_descr
-  | Some `Error   -> ci_descr ci target >>= fail "%a errored%a" Ref.pp_name ci pp_opt_descr
+  | None -> pending "Waiting for %a status to appear" Status.pp_context ci
+  | Some `Pending -> ci_descr ci target >>= pending "Waiting for %a to complete%a" Status.pp_context ci pp_opt_descr
+  | Some `Failure -> ci_descr ci target >>= fail "%a failed%a" Status.pp_context ci pp_opt_descr
+  | Some `Error   -> ci_descr ci target >>= fail "%a errored%a" Status.pp_context ci pp_opt_descr
   | Some `Success ->
     ci_state Status.url ci target >>= function
-    | None     -> fail "%a succeeded, but has no URL!" Ref.pp_name ci
+    | None     -> fail "%a succeeded, but has no URL!" Status.pp_context ci
     | Some url -> return url
 
 let run ~snapshot ~job_id ~recalc ~dk term =

--- a/ci/src/cI_term.mli
+++ b/ci/src/cI_term.mli
@@ -10,9 +10,9 @@ val head : CI_target.t -> Commit.t t
 val branch_head : Repo.t -> string -> Commit.t t
 val tag : Repo.t -> string -> Commit.t t
 val dk : (unit -> CI_utils.DK.t Lwt.t) t
-val ci_status : string list -> CI_target.t -> Status_state.t option t
-val ci_target_url : string list -> CI_target.t -> Uri.t option t
-val ci_success_target_url : string list -> CI_target.t -> Uri.t t
+val ci_status : Status.context -> CI_target.t -> Status_state.t option t
+val ci_target_url : Status.context -> CI_target.t -> Uri.t option t
+val ci_success_target_url : Status.context -> CI_target.t -> Uri.t t
 val run :
   snapshot:CI_utils.DK.Tree.t ->
   job_id:CI_s.job_id ->

--- a/ci/src/cI_utils.ml
+++ b/ci/src/cI_utils.ml
@@ -143,3 +143,5 @@ let cancel_when_off switch fn =
     (fun () -> Lwt.cancel th; Lwt.return ())
   >>= fun () ->
   th
+
+module Job_map = Asetmap.Map.Make(struct type t = Datakit_path.Step.t let compare = compare end)

--- a/ci/src/cI_utils.mli
+++ b/ci/src/cI_utils.mli
@@ -48,3 +48,5 @@ val ls: string -> string list Lwt.t
 val with_switch: (Lwt_switch.t -> 'a Lwt.t) -> 'a Lwt.t
 
 val cancel_when_off: Lwt_switch.t -> (unit -> 'a Lwt.t) -> 'a Lwt.t
+
+module Job_map : Asetmap.Map.S with type key = Datakit_path.Step.t

--- a/ci/src/cI_web_templates.ml
+++ b/ci/src/cI_web_templates.ml
@@ -2,6 +2,8 @@ open Datakit_github
 open! Astring
 open! Tyxml.Html
 
+module Job_map = CI_utils.Job_map
+
 type t = {
   name : string;
   state_repo : Uri.t option;
@@ -677,7 +679,7 @@ let job_row ~csrf_token ~page_url ~best_log (job_name, state) =
     | Some state -> state
   in
   tr [
-    th [pcdata job_name];
+    th [pcdata (Datakit_path.Step.to_string job_name)];
     td [status (CI_output.status output)];
     td (
       logs ~csrf_token ~page_url ~selected:best_log output
@@ -741,7 +743,7 @@ let history_nav t target state =
   | xs -> p (pcdata "Previous states: " :: (intersperse (pcdata ", ") (List.map state_link xs)) @ links)
 
 let target_page ~csrf_token ?(title="(no title)") ~(target:CI_target.t) state t =
-  let jobs = CI_history.State.jobs state |> String.Map.bindings |> List.map (fun (name, s) -> name, Some s) in
+  let jobs = CI_history.State.jobs state |> Job_map.bindings |> List.map (fun (name, s) -> name, Some s) in
   let title = target_title ~title target in
   let repo = CI_target.repo target in
   let commit = CI_history.State.source_commit state in

--- a/ci/src/datakit_ci.ml
+++ b/ci/src/datakit_ci.ml
@@ -29,6 +29,7 @@ module Web = struct
 end
 
 module Private = struct
+  module Job_map = Utils.Job_map
   module Client9p = Utils.Client9p
   type engine = CI_engine.t
   let connect = DK.connect

--- a/ci/src/datakit_ci.mli
+++ b/ci/src/datakit_ci.mli
@@ -278,18 +278,18 @@ module Term: sig
   (** [tag repo t] evaluates to the commit of tag [t] in the
       repository [repo]. *)
 
-  val ci_status: string list -> Target.t ->
+  val ci_status: Datakit_github.Status.context -> Target.t ->
     [`Pending | `Success | `Failure | `Error] option t
   (** [ci_status ci target] is the status reported by CI [ci] for
       [target].  Note that even if the CI is e.g. pending, this
       returns a successful result with the value [`Pending], not a
       pending result. *)
 
-  val ci_target_url: string list -> Target.t -> Uri.t option t
+  val ci_target_url: Datakit_github.Status.context -> Target.t -> Uri.t option t
   (** [ci_target_url ci target] is the target URL reported by CI
       [ci]. *)
 
-  val ci_success_target_url: string list -> Target.t -> Uri.t t
+  val ci_success_target_url: Datakit_github.Status.context -> Target.t -> Uri.t t
   (** [ci_success_target_url ci target] is the URL of the *successful*
       build [ci].  It is pending until a successful URL is
       available. *)
@@ -696,6 +696,8 @@ module Private: sig
 
   type engine
 
+  module Job_map : Asetmap.Map.S with type key = Datakit_path.Step.t
+
   module Client9p: sig
     include Protocol_9p_client.S
     val connect:
@@ -707,7 +709,7 @@ module Private: sig
   val connect: Client9p.t -> DK.t
 
   val test_engine: web_ui:Uri.t -> (unit -> DK.t Lwt.t) ->
-    (Target.t -> string Term.t Astring.String.Map.t)
+    (Target.t -> string Term.t Job_map.t)
       Datakit_github.Repo.Map.t ->
     engine
 

--- a/ci/tests/test_utils.ml
+++ b/ci/tests/test_utils.ml
@@ -223,6 +223,8 @@ let with_handler set_handler ~logs ?pending key fn =
 
 let repo_root { Repo.user; repo } = Datakit_path.(empty / user / repo)
 
+let test_job_id = Datakit_path.Step.of_string_exn "test"
+
 (* [with_ci conn workflow fn] is [fn ~logs ~switch dk with_handler], where:
    - switch is turned off when [fn] ends and will stop the CI
    - dk is a DataKit connection which never fails
@@ -239,7 +241,7 @@ let with_ci ?(repo=Repo.v ~user:"user" ~repo:"project") conn workflow fn =
   let web_ui = Uri.of_string "https://localhost/" in
   let dk = Private.connect conn in
   let ci = Private.test_engine ~web_ui (fun () -> Lwt.return dk)
-      (Repo.Map.singleton repo (fun t -> String.Map.singleton "test" (workflow check_build t)))
+      (Repo.Map.singleton repo (fun t -> Private.Job_map.singleton test_job_id (workflow check_build t)))
   in
   let switch = Lwt_switch.create () in
   let engine_thread =

--- a/src/datakit-client/datakit_path.mli
+++ b/src/datakit-client/datakit_path.mli
@@ -2,7 +2,19 @@
 
 open Result
 
-type t
+module Step : sig
+  type t = private string
+  (** One component in a path *)
+
+  val of_string : string -> (t, string) result
+  val of_string_exn : string -> t
+  val to_string : t -> string
+
+  val compare : t -> t -> int
+  val pp : t Fmt.t
+end
+
+type t = Step.t list
 (** A [path] identifies a file or directory (relative to some other directory).
     No component may be empty or contain a '/' character. "." and ".." steps
     are not permitted in a path. *)

--- a/src/datakit-github/datakit_github.mli
+++ b/src/datakit-github/datakit_github.mli
@@ -195,7 +195,7 @@ end
 
 module Status: sig
 
-  type context = string list
+  type context = Datakit_path.t
   (** The type build build status contexts. ["ci/datakit"] is stored
       as ["ci"; "datakit"]. *)
 
@@ -209,7 +209,7 @@ module Status: sig
   (** The type for status values. *)
 
   val v: ?description:string -> ?url:Uri.t ->
-    Commit.t -> string list -> Status_state.t -> t
+    Commit.t -> context -> Status_state.t -> t
   (** [v c n] is the status with commit [c] and name [n]. *)
 
   val pp: t Fmt.t
@@ -232,6 +232,13 @@ module Status: sig
 
   val context: t -> context
   (** [context t] is [t]'s context. *)
+
+  val context_of_path : string list -> (context, string) result
+  (** [context_of_path p] is the context [p], if it is a valid context. *)
+
+  val context_of_path_exn : string list -> context
+  (** [context_of_path_exn p] is the context [path].
+      It raises an exception if [p] is invalid. *)
 
   val state: t -> Status_state.t
   (** [state t] is [t]'s state. *)
@@ -576,7 +583,7 @@ module Capabilities: sig
     | `Repo of string list
     | `PR
     | `Commit
-    | `Status of string list
+    | `Status of Status.context
     | `Ref
     | `Webhook
   ]


### PR DESCRIPTION
Before, the CI would stop and log an error. Now, it displays "invalid-name" in the web UI and shows the error message as the job's result.

Fixes #371 