### PR TITLE
self-ci: update for new project location

### DIFF
--- a/ci/self-ci/Dockerfile
+++ b/ci/self-ci/Dockerfile
@@ -1,8 +1,14 @@
-FROM docker/datakit:ci
+FROM docker/datakit:ci AS build-env
 RUN sudo apk add --no-cache libev docker gmp
 ADD . /home/opam/build
 WORKDIR /home/opam/build
 RUN sudo chown opam .
 RUN opam config exec make selfCI
-ENTRYPOINT ["/home/opam/build/_build/selfCI.native"]
+RUN sudo cp selfCI.native /usr/local/bin/ci
+
+FROM alpine:3.5
+RUN apk add --no-cache libev docker gmp tzdata ca-certificates
+
 USER root
+ENTRYPOINT ["/usr/local/bin/ci"]
+COPY --from=build-env /usr/local/bin/ci /usr/local/bin/ci

--- a/ci/self-ci/Dockerfile.run
+++ b/ci/self-ci/Dockerfile.run
@@ -1,6 +1,0 @@
-FROM alpine:3.5
-RUN apk add --no-cache libev docker gmp
-USER root
-ENTRYPOINT ["/bin/self-ci"]
-CMD []
-ADD docker-self-ci /bin/self-ci

--- a/ci/self-ci/Makefile
+++ b/ci/self-ci/Makefile
@@ -5,12 +5,8 @@ all: selfCI
 %CI:
 	ocamlbuild ${OCAMLBUILD_FLAGS} $@.native
 
-# To keep the final image small, we copy the binary from the build image to a fresh base
 docker:
-	docker build -t self-ci-dev .
-	docker run --rm -i --entrypoint cat self-ci-dev _build/selfCI.native > docker-self-ci
-	chmod a+x docker-self-ci
-	docker build -t editions/datakit-self-ci -f Dockerfile.run .
+	docker build -t editions/datakit-self-ci .
 
 clean:
 	ocamlbuild -clean

--- a/ci/self-ci/README.md
+++ b/ci/self-ci/README.md
@@ -17,7 +17,7 @@ Visit the URL shown to configure an admin user.
 In this configuration:
 
 - The bridge that normally syncs the CI state with GitHub is replaced by `docker/datakit:bridge-local-git`, which tracks the local DataKit Git repository (`../../.git`).
-- Only the master branch is tested (`--canary=docker/datakit/heads/master`).
+- Only the master branch is tested (`--canary=moby/datakit/heads/master`).
 - Plain HTTP connections are used, to avoid browser warnings about self-signed certificates when testing.
 - The main executable is called with `--profile=localhost`, which affects some settings in `selfCI.ml` (search for `Localhost` to find the changes).
 
@@ -73,6 +73,6 @@ The `bridge` service should then start populating the branch with information ab
 
 All the DataKit services are run with `--listen-prometheus=9090`, which means that they will provide Prometheus metrics on port 9090 at `/metrics`. You can configure a Prometheus server to monitor these ports.
 
-[DataKitCI]: https://github.com/docker/datakit/tree/master/ci/self-ci
+[DataKitCI]: https://github.com/moby/datakit/tree/master/ci/self-ci
 [ocaml-github]: https://github.com/mirage/ocaml-github
 [certbot]: https://certbot.eff.org/

--- a/ci/self-ci/datakit-ci.yml
+++ b/ci/self-ci/datakit-ci.yml
@@ -20,7 +20,7 @@ services:
       - '/var/run/datakit:/var/run/builder'
   datakit:
     user: 'root'
-    command: '--git /data --listen-prometheus=9090 --listen-9p tcp://0.0.0.0:5640 --auto-push git@github.com:docker/datakit.logs'
+    command: '--git /data --listen-prometheus=9090 --listen-9p tcp://0.0.0.0:5640 --auto-push git@github.com:moby/datakit.logs'
     image: 'docker/datakit:latest'
     volumes:
       - datakit-public-data:/data

--- a/ci/self-ci/docker-compose.yml
+++ b/ci/self-ci/docker-compose.yml
@@ -4,14 +4,14 @@ services:
   # Also, we use --canary to test only the master branch.
   # For production use datakit-ci.yml, which tests against GitHub.
   bridge:
-    command: '--metadata-store tcp:datakit:5640 -v docker/datakit:/data/repos/datakit'
+    command: '--metadata-store tcp:datakit:5640 -v moby/datakit:/data/repos/datakit'
     image: 'docker/datakit:bridge-local-git'
     links:
       - datakit
     volumes:
       - '../../.git:/data/repos/datakit/.git:ro'
   ci:
-    command: '--profile=localhost --metadata-store tcp:datakit:5640 --web-ui=http://localhost:8080/ --canary=docker/datakit/heads/master'
+    command: '--profile=localhost --metadata-store tcp:datakit:5640 --web-ui=http://localhost:8080/ --canary=moby/datakit/heads/master'
     build: .
     links:
       - datakit

--- a/ci/self-ci/selfCI.ml
+++ b/ci/self-ci/selfCI.ml
@@ -91,7 +91,7 @@ module Tests = struct
 end
 
 let projects repo = [
-  Config.project ~id:"docker/datakit" (Tests.datakit repo)
+  Config.project ~id:"moby/datakit" (Tests.datakit repo)
 ]
 
 let make_config ?state_repo ~listen_addr ~remote () =
@@ -110,8 +110,8 @@ let make_config ?state_repo ~listen_addr ~remote () =
 let config_for = function
   | `Production ->
     make_config
-      ~remote:"https://github.com/docker/datakit.git"
-      ~state_repo:(Uri.of_string "https://github.com/docker/datakit.logs")
+      ~remote:"https://github.com/moby/datakit.git"
+      ~state_repo:(Uri.of_string "https://github.com/moby/datakit.logs")
       ~listen_addr:(`HTTP 8080) (* We live behind an nginx proxy. *)
       ()
   | `Localhost ->

--- a/ci/src/cI_docker.ml
+++ b/ci/src/cI_docker.ml
@@ -95,12 +95,15 @@ module Builder = struct
       match String.cut ~sep:"\n" contents with
       | None -> CI_utils.failf "Missing newline in %S" path
       | Some (first, rest) ->
-        if not (String.is_prefix ~affix:"FROM " (String.Ascii.uppercase first)) then
-          CI_utils.failf "Dockerfile %S starts %S, not 'FROM '" path first;
-        let first = Printf.sprintf "FROM %s" (Image.id base) in
-        CI_live_log.log log "Rewrite Dockerfile's first line to:@\n%s" first;
-        let contents = Printf.sprintf "%s\n%s" first rest in
-        Lwt_io.with_file ~mode:Lwt_io.output path (fun ch -> Lwt_io.write ch contents)
+        match String.cuts ~sep:" " first with
+        | "FROM" :: _base :: trailing ->
+          let first = Fmt.strf "FROM %a"
+              (Fmt.list ~sep:Fmt.(const string " ") Fmt.string) (Image.id base :: trailing) in
+          CI_live_log.log log "Rewrite Dockerfile's first line to:@\n%s" first;
+          let contents = Printf.sprintf "%s\n%s" first rest in
+          Lwt_io.with_file ~mode:Lwt_io.output path (fun ch -> Lwt_io.write ch contents)
+        | _ ->
+          CI_utils.failf "Dockerfile %S starts %S, not 'FROM '" path first
 
   let build ~pull ~q dockerfile =
     let pull = if pull then ["--pull"] else [] in


### PR DESCRIPTION
docker/datakit is now moby/datakit.

Signed-off-by: Thomas Leonard <thomas.leonard@docker.com>