### PR TITLE
Use nested builds to shrink images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #FROM ocaml/opam-dev:alpine-3.5_ocaml-4.04.0
 FROM ocaml/opam-dev@sha256:573b5d71e94104590a8282a9ae67b63a6144b15bafdacb9980391c84ca730615
 ENV OPAMERRLOGLEN=0 OPAMYES=1
-RUN sudo apk add tzdata aspcud
+RUN sudo apk add tzdata aspcud gmp-dev perl
 
 RUN opam pin add -yn protocol-9p.0.8.0 'https://github.com/talex5/ocaml-9p.git#ping'
 RUN opam depext -ui lwt inotify alcotest conf-libev lambda-term asl win-eventlog camlzip irmin-watcher mtime mirage-flow conduit hvsock cohttp prometheus-app git.1.9.3 mirage-tc irmin.0.12.0 cmdliner.0.9.8 protocol-9p channel rresult win-error named-pipe
@@ -30,17 +30,15 @@ RUN cd /home/opam/src/datakit && \
     git checkout . && scripts/watermark.sh && \
     git status --porcelain
 
-RUN opam install datakit -y
+RUN opam install datakit -ytv
 
 RUN sudo cp $(opam config exec -- which datakit) /usr/bin/datakit && \
     sudo cp $(opam config exec -- which datakit-mount) /usr/bin/datakit-mount
 
-USER root
-
-#FROM alpine:3.5
-#RUN apk add --no-cache libev gmp tzdata ca-certificates
+FROM alpine:3.5
+RUN apk add --no-cache libev gmp tzdata ca-certificates git openssh-client bash
 EXPOSE 5640
 ENTRYPOINT ["/usr/bin/datakit"]
 CMD ["--url=tcp://0.0.0.0:5640", "--git=/data", "-v"]
-#COPY --from=0 /usr/bin/datakit /usr/bin/datakit
-#COPY --from=0 /usr/bin/datakit-mount /usr/bin/datakit-mount
+COPY --from=0 /usr/bin/datakit /usr/bin/datakit
+COPY --from=0 /usr/bin/datakit-mount /usr/bin/datakit-mount

--- a/Dockerfile.github
+++ b/Dockerfile.github
@@ -5,7 +5,7 @@ RUN sudo apk add tzdata aspcud
 
 RUN opam pin add -yn protocol-9p.0.8.0 'https://github.com/talex5/ocaml-9p.git#ping'
 RUN opam pin add github --dev -n
-RUN opam depext -ui lwt inotify alcotest conf-libev lambda-term cmdliner.0.9.8 github protocol-9p rresult prometheus-app mirage-types-lwt.2.8.0 asl win-eventlog mtime hex github-hooks hvsock
+RUN opam depext -ui lwt inotify alcotest conf-libev lambda-term cmdliner.0.9.8 github protocol-9p rresult prometheus-app mirage-types-lwt.2.8.0 asl win-eventlog mtime hex github-hooks hvsock camlzip irmin-watcher datakit-server git mirage-tc irmin.0.12.0
 
 COPY check-libev.ml /tmp/check-libev.ml
 RUN opam config exec -- ocaml /tmp/check-libev.ml
@@ -27,16 +27,16 @@ RUN cd /home/opam/src/datakit && \
     git checkout . && scripts/watermark.sh && \
     git status --porcelain
 
-RUN opam install datakit-bridge-github -y
+RUN opam install datakit-bridge-github -ytv
 
 RUN sudo cp $(opam config exec -- which datakit-bridge-github) /usr/bin/
 
 USER root
 
-#FROM alpine:3.5
-#RUN apk add --no-cache libev gmp tzdata ca-certificates
+FROM alpine:3.5
+RUN apk add --no-cache libev gmp tzdata ca-certificates
 EXPOSE 5640
 EXPOSE 5641
 ENTRYPOINT ["/usr/bin/datakit-bridge-github"]
 CMD ["--listen=tcp://0.0.0.0:5641", "-v", "--datakit=tcp:127.0.0.1:5640"]
-#COPY --from=0 /usr/bin/datakit-bridge-github /usr/bin/datakit-bridge-github
+COPY --from=0 /usr/bin/datakit-bridge-github /usr/bin/datakit-bridge-github

--- a/ci/self-ci/selfCI.ml
+++ b/ci/self-ci/selfCI.ml
@@ -36,8 +36,6 @@ let opam_test ?depexts pkg =
   Docker.command ~logs ~pool ~user:"opam" ~timeout:(30. *. minute) ~label:("test-" ^ pkg) ~entrypoint ["-c"; cmd]
 
 let opam_test_ci = opam_test "datakit-ci" ~depexts:["conf-autoconf"; "conf-libpcre"; "camlzip"]
-let opam_test_datakit = opam_test "datakit" ~depexts:["conf-gmp"; "conf-libpcre"; "conf-perl"; "conf-autoconf"]
-
 module Tests = struct
   open Term.Infix
 
@@ -78,7 +76,7 @@ module Tests = struct
         "ci",          run_tests    images#ci           opam_test_ci;
         "self-ci",     check_builds images#self_ci;
         "github",      check_builds images#github;
-        "datakit",     run_tests    images#datakit      opam_test_datakit;
+        "datakit",     check_builds images#datakit;
         "local-git",   check_builds images#local_git;
         "libraries",   Term.wait_for_all [
           "client",      check_builds images#client;


### PR DESCRIPTION
When hub supports this, it reduces the image sizes quite a bit:
    
datakit : 1.4 G -> 21 M
github  : 1.7 G -> 22 M