### PR TITLE
Go: Separate user config from defaults in the database

### DIFF
--- a/api/go-datakit/client.go
+++ b/api/go-datakit/client.go
@@ -265,3 +265,55 @@ func (f *FileReader) Read(p []byte) (int, error) {
 	}
 	return n, err
 }
+
+type ioFileReaderWriter struct {
+	f      *File
+	ctx    context.Context
+	offset int64
+}
+
+// NewIOReader creates a standard io.Reader at a given position in the file
+func (f *File) NewIOReader(ctx context.Context, offset int64) io.Reader {
+	return &ioFileReaderWriter{f, ctx, offset}
+}
+
+// NewIOWriter creates a standard io.Writer at a given position in the file
+func (f *File) NewIOWriter(ctx context.Context, offset int64) io.Writer {
+	return &ioFileReaderWriter{f, ctx, offset}
+}
+
+func (r *ioFileReaderWriter) Read(p []byte) (n int, err error) {
+	if len(p) > r.f.c.session.MaxReadSize() {
+		p = p[:r.f.c.session.MaxReadSize()]
+	}
+	r.f.m.Lock()
+	defer r.f.m.Unlock()
+	n, err = r.f.c.session.Read(r.ctx, r.f.fid, p, r.offset)
+	r.offset += int64(n)
+	// additional error handling for compliying with io.Reader
+	if n < len(p) && err == nil {
+		err = io.EOF
+	}
+	return
+}
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+func (w *ioFileReaderWriter) Write(p []byte) (n int, err error) {
+	w.f.m.Lock()
+	defer w.f.m.Unlock()
+	for err == nil {
+		var written int
+		written, err = w.f.c.session.Write(w.ctx, w.f.fid, p[:minInt(len(p), w.f.c.session.MaxWriteSize())], w.offset)
+		p = p[written:]
+		w.offset += int64(written)
+		n += written
+		if len(p) == 0 {
+			break
+		}
+	}
+	return
+}

--- a/api/go-datakit/client.go
+++ b/api/go-datakit/client.go
@@ -181,7 +181,10 @@ func (c *Client) Create(ctx context.Context, path ...string) (*File, error) {
 	dir := path[0 : len(path)-1]
 	_, err = c.session.Walk(ctx, fid, fid, dir...)
 	if err != nil {
-		log.Println("Failed to Walk to", path, err)
+		if err != enoent {
+			// This is a common error
+			log.Println("Failed to Walk to", path, err)
+		}
 		c.freeFid(ctx, fid)
 		return nil, err
 	}
@@ -202,7 +205,10 @@ func (c *Client) Open(ctx context.Context, mode p9p.Flag, path ...string) (*File
 	}
 	_, err = c.session.Walk(ctx, fid, fid, path...)
 	if err != nil {
-		log.Println("Failed to Walk to", path, err)
+		if err != enoent {
+			// This is a common error
+			log.Println("Failed to Walk to", path, err)
+		}
 		c.freeFid(ctx, fid)
 		return nil, err
 	}

--- a/api/go-datakit/config.go
+++ b/api/go-datakit/config.go
@@ -29,6 +29,18 @@ type Record struct {
 func NewRecord(ctx context.Context, client *Client, lookupB []string, defaultsB string, path []string) (*Record, error) {
 	event := make(chan (interface{}), 0)
 	for _, b := range lookupB {
+		// Create the branch if it doesn't exist
+		t, err := NewTransaction(ctx, client, b, b+".init")
+		if err != nil {
+			log.Fatalf("Failed to open a new transaction: %#v", err)
+		}
+		if err = t.Write(ctx, []string{"branch-created"}, ""); err != nil {
+			log.Fatalf("Failed to write branch-created: %#v", err)
+		}
+		if err = t.Commit(ctx, "Creating branch"); err != nil {
+			log.Fatalf("Failed to commit transaction: %#v", err)
+		}
+
 		if err := client.Mkdir(ctx, "branch", b); err != nil {
 			return nil, err
 		}

--- a/api/go-datakit/config_test.go
+++ b/api/go-datakit/config_test.go
@@ -21,7 +21,7 @@ func TestConfig(t *testing.T) {
 		t.Fatalf("Failed to connect to db: %v", err)
 	}
 
-	r, err := NewRecord(ctx, client, []string{"master"}, "master", []string{"tests"})
+	r, err := NewRecord(ctx, client, []string{"master", "defaults"}, "defaults", []string{"tests"})
 	if err != nil {
 		t.Fatalf("NewRecord failed: %v", err)
 	}

--- a/api/go-datakit/config_test.go
+++ b/api/go-datakit/config_test.go
@@ -21,7 +21,7 @@ func TestConfig(t *testing.T) {
 		t.Fatalf("Failed to connect to db: %v", err)
 	}
 
-	r, err := NewRecord(ctx, client, "master", "master", []string{"tests"})
+	r, err := NewRecord(ctx, client, []string{"master"}, "master", []string{"tests"})
 	if err != nil {
 		t.Fatalf("NewRecord failed: %v", err)
 	}

--- a/api/go-datakit/config_test.go
+++ b/api/go-datakit/config_test.go
@@ -21,7 +21,7 @@ func TestConfig(t *testing.T) {
 		t.Fatalf("Failed to connect to db: %v", err)
 	}
 
-	r, err := NewRecord(ctx, client, "master", []string{"tests"})
+	r, err := NewRecord(ctx, client, "master", "master", []string{"tests"})
 	if err != nil {
 		t.Fatalf("NewRecord failed: %v", err)
 	}

--- a/api/go-datakit/snapshot.go
+++ b/api/go-datakit/snapshot.go
@@ -69,7 +69,7 @@ func (s *Snapshot) Read(ctx context.Context, path []string) (string, error) {
 		return "", err
 	}
 	defer file.Close(ctx)
-	reader := file.NewFileReader(ctx)
+	reader := file.NewIOReader(ctx, 0)
 	buf := bytes.NewBuffer(nil)
 	io.Copy(buf, reader)
 	return string(buf.Bytes()), nil

--- a/api/go-datakit/transaction.go
+++ b/api/go-datakit/transaction.go
@@ -88,7 +88,8 @@ func (t *transaction) Write(ctx context.Context, path []string, value string) er
 		return err
 	}
 	defer file.Close(ctx)
-	_, err = file.Write(ctx, []byte(value), 0)
+	writer := file.NewIOWriter(ctx, 0)
+	_, err = writer.Write([]byte(value))
 	if err != nil {
 		log.Println("Failed to Write", path, "=", value, ":", err)
 		return err


### PR DESCRIPTION
Previously the database had a single `master` branch containing a mixture of user-specified configuration; runtime internal state and defaults. This meant that in Docker for Mac

- the "schema" upgrade can't tell the difference between a user setting and a default setting, so it resets everything, leading to user suffering and hotfixes. In practice this means we can't use the schema upgrade mechanism any more.
- some keys have an ad-hoc user override mechanism (e.g. the DNS and HTTP proxy keys)
- we don't have a way to change a default for some users (e.g. to enable an experimental feature) while allowing them to opt out by turning it off

These patches use branches to separate the notions of

- user overrides stored in the `master` branch as before
- system defaults stored in the `defaults` branch
- experimental features stored in the `experimental` branch
- the configuration in-effect computed from the previous 3 branches in the `state` branch

On application start we populate the `defaults` branch (and later we will populate the `experimental` branch).

On upgrade we scan the existing `master` branch and identify (by ugly string matching on commit messages) those keys which have not been changed by the user. These keys are deleted so that the keys in the `default` (or `experimental`) branch are used in preference.

When the UI calls `setvmsettings` these overrides are written to the `master` branch. When the UI calls `getvmsettings` the derived values are read from the `state` branch.

`vpnkit` has been modified to read its configuration from the `state` branch. For the moment we write the Moby-relevant keys also to the `master` branch pending a future update to moby which will look at the `state` branch instead.

To see this code in action, download the latest Docker for Mac from the edge channel and take a look at the database directory.