### PR TITLE
datakit: do not expose an HTTP server anymore

### DIFF
--- a/_tags
+++ b/_tags
@@ -23,8 +23,8 @@ true: package(bytes lwt astring logs result cstruct fmt rresult)
 <src/datakit/*>: package(prometheus-app.unix)
 <src/datakit/main.*>: package(cmdliner fmt.cli fmt.tty logs.fmt asetmap)
 <src/datakit/main.*>: package(git irmin irmin.git irmin.mem irmin-watcher)
-<src/datakit/main.*>: package(irmin.http cohttp.lwt irmin-watcher), thread
-<src/datakit/main.*>: package(protocol-9p.unix camlzip), thread
+<src/datakit/main.*>: package(irmin-watcher), thread
+<src/datakit/main.*>: package(protocol-9p.unix camlzip)
 
 ### datakit-conduit
 <src/datakit_conduit.*>: thread, package(threads conduit.lwt-unix hvsock.lwt)

--- a/opam
+++ b/opam
@@ -27,9 +27,8 @@ depends: [
   "camlzip"     {>= "1.06"}
   "cstruct"     {>= "2.2"}
   "result"
-  "lwt"	        {>= "2.7.0"}
+  "lwt"         {>= "2.7.0"}
   "conduit" "mirage-flow"
-  "cohttp"
   "named-pipe"  {>= "0.4.0"}
   "hvsock"      {>= "0.8.1"}
   "logs"        {>= "0.5.0"}


### PR DESCRIPTION
It was useful only for debugging, and Irmin 1.0 does not support it anymore.

Signed-off-by: Thomas Gazagnaire <thomas@gazagnaire.org>