### PR TITLE
Rename repos and update project links

### DIFF
--- a/9p.md
+++ b/9p.md
@@ -221,12 +221,12 @@ to add a new configuration. Every configuration folder contains:
   commit ID of the remote. On every fetch, a new line is added
   with the commit ID of the remote branch.
 
-To fetch `https://github.com/docker/datakit`'s master branch using the
+To fetch `https://github.com/moby/datakit`'s master branch using the
 git protocol:
 
     ~/db $ cd remotes
     ~/db/remotes $ mkdir origin
-    ~/db/remotes $ echo git://github.com/docker/datakit > origin/url
+    ~/db/remotes $ echo git://github.com/moby/datakit > origin/url
     ~/db/remotes $ echo master > origin/fetch
     ~/db/remotes $ cat origin/head
     4b6557542ec9cc578d5fe09b664110ba3b68e2c2
@@ -235,11 +235,11 @@ git protocol:
 
 There is basic support for interacting with GitHub PRs.
 
-    ~/db $ ls github.com/docker/datakit
+    ~/db $ ls github.com/moby/datakit
     41  42
-    ~/db $ cat github.com/docker/datakit/pr/41/status/default/state
+    ~/db $ cat github.com/moby/datakit/pr/41/status/default/state
     pending
-    ~/db $ echo success > github.com/docker/datakit/pr/41/status/default/state
+    ~/db $ echo success > github.com/moby/datakit/pr/41/status/default/state
 
 
 This first queries the status of the pull request on the GitHub interface,
@@ -247,7 +247,7 @@ then updates the `default` status to `success`.
 
 To create a new status and set its description, url and status:
 
-    ~/db $ PR=github.com/docker/datakit/pr/41
+    ~/db $ PR=github.com/moby/datakit/pr/41
     ~/db $ mkdir $PR/status/test
     ~/db $ echo "My status" > $PR/status/test/descr
     ~/db $ echo "http://example.com" > $PR/status/test/url
@@ -255,7 +255,7 @@ To create a new status and set its description, url and status:
 
 To read the last GitHub events related to a repository:
 
-    ~/db $ cat github.com/docker/datakit/events
+    ~/db $ cat github.com/moby/datakit/events
 
 This is a non-blocking read, and will produce a file where every line is a new
 event.

--- a/Dockerfile.bridge-local-git
+++ b/Dockerfile.bridge-local-git
@@ -1,4 +1,4 @@
-FROM docker/datakit:client
+FROM datakit/client
 
 RUN opam pin add github --dev -n
 RUN opam pin add datakit-github.dev /home/opam/src/datakit -n

--- a/Dockerfile.bridge-local-git
+++ b/Dockerfile.bridge-local-git
@@ -20,6 +20,7 @@ RUN opam install datakit-bridge-local-git -vv
 RUN opam config exec -- ocaml /home/opam/src/datakit/check-libev.ml
 RUN sudo cp $(opam config exec -- which datakit-bridge-local-git) /usr/bin/
 
-USER root
+FROM alpine:3.5
+RUN apk add --no-cache libev gmp tzdata ca-certificates
 ENTRYPOINT ["/usr/bin/datakit-bridge-local-git"]
-CMD ["-v", "--datakit=tcp:datakit:5640"]
+COPY --from=0 /usr/bin/datakit-bridge-local-git /usr/bin/datakit-bridge-local-git

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -4,19 +4,12 @@ ENV OPAMERRLOGLEN=0 OPAMYES=1
 RUN sudo apk add tzdata aspcud
 
 RUN opam pin add -yn protocol-9p.0.8.0 'https://github.com/talex5/ocaml-9p.git#ping'
-RUN opam pin add -yn datakit-client.dev https://github.com/docker/datakit.git
-
-ADD datakit-ci.opam /tmp/deps/opam
-RUN opam pin add -y tmp /tmp/deps/opam -n
-RUN opam depext tmp -y
-RUN opam install --deps-only tmp -y
+RUN opam depext -i asl win-eventlog camlzip alcotest mtime mirage-flow datakit-server hvsock git mirage-tc irmin irmin-unix lwt protocol-9p.0.8.0 tyxml redis multipart-form-data pbkdf tls prometheus-app github git session irmin.0.12.0 irmin-unix.0.12.0 cmdliner.0.9.8 webmachine
 
 ADD . /home/opam/datakit
 RUN sudo chown opam /home/opam/datakit
 RUN opam pin add -k git datakit-client.dev /home/opam/datakit -y
-RUN opam pin add -k git datakit-ci.dev /home/opam/datakit -y
-
-# Needed if we decide to run the tests
-RUN opam pin add -k git datakit-github.dev /home/opam/datakit -yn
+RUN opam pin add -k git datakit-github.dev /home/opam/datakit -y
+RUN opam pin add -k git datakit-ci.dev /home/opam/datakit -yt
 
 VOLUME /secrets

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,6 +1,6 @@
 # DataKit maintainers file
 #
-# This file describes who runs the docker/datakit project and how.
+# This file describes who runs the moby/datakit project and how.
 # This is a living document - if you see something out of date or missing, speak up!
 #
 # It is structured to be consumable by both humans and programs.

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ for the [DataKitCI][] continuous integration system.
 
 ---
 
-[![Build Status (OSX, Linux)](https://travis-ci.org/docker/datakit.svg)](https://travis-ci.org/docker/datakit)
-[![Build status (Windows)](https://ci.appveyor.com/api/projects/status/6qrdgiqbhi4sehmy/branch/master?svg=true)](https://ci.appveyor.com/project/docker/datakit/branch/master)
+[![Build Status (OSX, Linux)](https://travis-ci.org/moby/datakit.svg)](https://travis-ci.org/moby/datakit)
+[![Build status (Windows)](https://ci.appveyor.com/api/projects/status/6qrdgiqbhi4sehmy/branch/master?svg=true)](https://ci.appveyor.com/project/moby/datakit/branch/master)
 [![docs](https://img.shields.io/badge/doc-online-blue.svg)](https://docker.github.io/datakit/)
 
 There are several components in this repository:
@@ -34,7 +34,7 @@ To expose a Git repository as a 9p endpoint on port 5640 on a private network, r
 
 ```shell
 $ docker network create datakit-net # create a private network
-$ docker run -it --net datakit-net --name datakit -v <path/to/git/repo>:/data docker/datakit
+$ docker run -it --net datakit-net --name datakit -v <path/to/git/repo>:/data datakit/db
 ```
 
 *Note*: The `--name datakit` option is mandatory.  It will allow the client
@@ -45,7 +45,7 @@ expose the database as a filesystem API:
 
 ```shell
 # In an other terminal
-$ docker run -it --privileged --net datakit-net docker/datakit:client
+$ docker run -it --privileged --net datakit-net datakit/client
 $ ls /db
 branch     remotes    snapshots  trees
 ```
@@ -61,12 +61,12 @@ for more details.
 
 The easiest way to build the DataKit project is to use [docker](https://docker.com),
 (which is what the
-[start-datakit.sh](https://github.com/docker/datakit/blob/master/scripts/start-datakit.sh) script
+[start-datakit.sh](https://github.com/moby/datakit/blob/master/scripts/start-datakit.sh) script
 does under the hood):
 
 ```shell
-docker build -t docker/datakit -f Dockerfile .
-docker run -p 5640:5640 -it --rm docker/datakit --listen-9p=tcp://0.0.0.0:5640
+docker build -t datakit/db -f Dockerfile .
+docker run -p 5640:5640 -it --rm datakit/db --listen-9p=tcp://0.0.0.0:5640
 ```
 These commands will expose the database's 9p endpoint on port 5640.
 
@@ -102,8 +102,8 @@ want to collect metrics remotely.
 ## Licensing
 
 DataKit is licensed under the Apache License, Version 2.0. See
-[LICENSE](https://github.com/docker/datakit/blob/master/LICENSE.md) for the full
+[LICENSE](https://github.com/moby/datakit/blob/master/LICENSE.md) for the full
 license text.
 
-[DataKitCI]: https://github.com/docker/datakit/tree/master/ci
-[Filesystem API]: https://github.com/docker/datakit/tree/master/9p.md
+[DataKitCI]: https://github.com/moby/datakit/tree/master/ci
+[Filesystem API]: https://github.com/moby/datakit/tree/master/9p.md

--- a/bridge/github/README.md
+++ b/bridge/github/README.md
@@ -61,14 +61,3 @@ Replace:
 
 Connect to DataKit and create an empty file `repo/project/.monitor` on the `github-metadata` branch.
 The bridge will immediately start querying GitHub and will populate the directory with information about the project.
-
-### Experimental GitHub API bindings
-
-To start DataKit with the experimental GitHub bindings:
-
-```shell
-$ docker run -it --net datakit-net --name datakit -v <path/to/git/repo>:/data docker/datakit:github
-$ docker run -it --privileged --net datakit-net docker/datakit:client
-$ ls /db
-branch      github.com  remotes     snapshots   trees
-```

--- a/bridge/local/README.md
+++ b/bridge/local/README.md
@@ -21,20 +21,20 @@ For an example test configuration using this bridge, see `ci/self-ci/docker-comp
 
 Build using the `Dockerfile.bridge-local-git` file at the root of this repository:
 
-    docker build -t docker/datakit:bridge-local-git -f Dockerfile.bridge-local-git .
+    docker build -t datakit/local-bridge -f Dockerfile.bridge-local-git .
 
 ### Run
 
 To see the help text:
 
-    docker run -it --rm docker/datakit:bridge-local-git --help
+    docker run -it --rm datakit/local-bridge --help
 
 To run it (after starting a DataKit container called "datakit"):
 
     docker run -it --rm \
       --link datakit:datakit \
       -v /path/to/repos:/repos \
-      docker/datakit:bridge-local-git -v \
+      datakit/local-bridge -v \
       me/my-project:/repos/my-project \
       --verbose \
       --webhook=http://my-ip

--- a/ci/README.md
+++ b/ci/README.md
@@ -220,9 +220,9 @@ is a GitHub user who can read the "my-org/my-private-repository" repository.
 
 
 
-[DataKit]: https://github.com/docker/datakit
+[DataKit]: https://github.com/moby/datakit
 [cmdliner]: http://erratique.ch/software/cmdliner/doc/Cmdliner
 [DataKitCI API]: https://docker.github.io/datakit/Datakit_ci.html
 [MirageCI service]: https://ci.mirage.io/
 [MirageCI source]: https://github.com/avsm/mirage-ci/tree/master/src-bin
-[SelfCI]: https://github.com/docker/datakit/blob/master/ci/self-ci/selfCI.ml
+[SelfCI]: https://github.com/moby/datakit/blob/master/ci/self-ci/selfCI.ml

--- a/ci/self-ci/Dockerfile
+++ b/ci/self-ci/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker/datakit:ci AS build-env
+FROM datakit/ci AS build-env
 RUN sudo apk add --no-cache libev docker gmp
 ADD . /home/opam/build
 WORKDIR /home/opam/build

--- a/ci/self-ci/README.md
+++ b/ci/self-ci/README.md
@@ -16,7 +16,7 @@ Visit the URL shown to configure an admin user.
 
 In this configuration:
 
-- The bridge that normally syncs the CI state with GitHub is replaced by `docker/datakit:bridge-local-git`, which tracks the local DataKit Git repository (`../../.git`).
+- The bridge that normally syncs the CI state with GitHub is replaced by `datakit/local-bridge`, which tracks the local DataKit Git repository (`../../.git`).
 - Only the master branch is tested (`--canary=moby/datakit/heads/master`).
 - Plain HTTP connections are used, to avoid browser warnings about self-signed certificates when testing.
 - The main executable is called with `--profile=localhost`, which affects some settings in `selfCI.ml` (search for `Localhost` to find the changes).
@@ -32,7 +32,7 @@ To use this as a template for your own projects:
    - For the `ci` service:
      - Change `--web-ui=https://datakit.datakit.ci/` to the URL users should use to see the web user interface of your service.
    - For the `datakit` service:
-     - Edit (or remove) the `--auto-push git@github.com:docker/datakit.logs` option to point at a new, empty, GitHub repository
+     - Edit (or remove) the `--auto-push git@github.com:moby/datakit.logs` option to point at a new, empty, GitHub repository
        which will mirror the results.
    - For the bridge, change `--webhook http://HOST:PORT` to a public endpoint that GitHub can use to send web events.
      If you change the port, change *both* ports in the `ports` configuration below.

--- a/ci/self-ci/datakit-ci.yml
+++ b/ci/self-ci/datakit-ci.yml
@@ -3,7 +3,7 @@ version: '3.1'
 services:
   bridge:
     command: '--listen-prometheus=9090 --datakit tcp://datakit:5640 --no-listen -v -c "*:r,status[ci/datakit]:x,webhook:rw" --webhook http://hooks.datakit.ci:81 --log-destination timestamp'
-    image: 'docker/datakit:github'
+    image: 'datakit/github-bridge'
     ports:
       - '81:81'
     secrets:
@@ -21,7 +21,7 @@ services:
   datakit:
     user: 'root'
     command: '--git /data --listen-prometheus=9090 --listen-9p tcp://0.0.0.0:5640 --auto-push git@github.com:moby/datakit.logs'
-    image: 'docker/datakit:latest'
+    image: 'datakit/db'
     volumes:
       - datakit-public-data:/data
       - datakit-ssh:/root/.ssh

--- a/ci/self-ci/docker-compose.yml
+++ b/ci/self-ci/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   # For production use datakit-ci.yml, which tests against GitHub.
   bridge:
     command: '--metadata-store tcp:datakit:5640 -v moby/datakit:/data/repos/datakit'
-    image: 'docker/datakit:bridge-local-git'
+    image: 'datakit/local-bridge'
     links:
       - datakit
     volumes:
@@ -24,6 +24,6 @@ services:
   datakit:
     user: 'root'
     command: '--git /data --listen-9p tcp://0.0.0.0:5640'
-    image: 'docker/datakit:latest'
+    image: 'datakit/db'
     volumes:
       - /data

--- a/ci/skeleton/Dockerfile
+++ b/ci/skeleton/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker/datakit:ci
+FROM datakit/ci
 
 ARG CONFIG=exampleCI
 ADD . /datakit-ci

--- a/datakit-bridge-github.opam
+++ b/datakit-bridge-github.opam
@@ -3,9 +3,9 @@ maintainer:   "thomas@gazagnaire.org"
 authors:      ["Thomas Leonard" "Magnus Skjegstad"
                "David Scott" "Thomas Gazagnaire"]
 license:      "Apache"
-homepage:     "https://github.com/docker/datakit"
-bug-reports:  "https://github.com/docker/datakit/issues"
-dev-repo:     "https://github.com/docker/datakit.git"
+homepage:     "https://github.com/moby/datakit"
+bug-reports:  "https://github.com/moby/datakit/issues"
+dev-repo:     "https://github.com/moby/datakit.git"
 doc:          "https://docker.github.io/datakit/"
 
 build: [

--- a/datakit-bridge-local-git.opam
+++ b/datakit-bridge-local-git.opam
@@ -2,9 +2,9 @@ opam-version: "1.2"
 maintainer:   "thomas.leonard@docker.com"
 authors:      ["Thomas Leonard"]
 license:      "Apache"
-homepage:     "https://github.com/docker/datakit"
-bug-reports:  "https://github.com/docker/datakit/issues"
-dev-repo:     "https://github.com/docker/datakit.git"
+homepage:     "https://github.com/moby/datakit"
+bug-reports:  "https://github.com/moby/datakit/issues"
+dev-repo:     "https://github.com/moby/datakit.git"
 doc:          "https://docker.github.io/datakit/"
 
 build: [

--- a/datakit-ci.opam
+++ b/datakit-ci.opam
@@ -3,9 +3,9 @@ maintainer:   "datakit@docker.com"
 authors:      ["Thomas Leonard" "Anil Madhavapeddy"
                "Dave Tucker" "Thomas Gazagnaire" ]
 license:      "Apache"
-homepage:     "https://github.com/docker/datakit"
-bug-reports:  "https://github.com/docker/datakit/issues"
-dev-repo:     "https://github.com/docker/datakit.git"
+homepage:     "https://github.com/moby/datakit"
+bug-reports:  "https://github.com/moby/datakit/issues"
+dev-repo:     "https://github.com/moby/datakit.git"
 doc:          "https://docker.github.io/datakit/"
 
 build: [

--- a/datakit-client.opam
+++ b/datakit-client.opam
@@ -3,9 +3,9 @@ maintainer:   "thomas@gazagnaire.org"
 authors:      ["Thomas Leonard" "Magnus Skjegstad"
                "David Scott" "Thomas Gazagnaire"]
 license:      "Apache"
-homepage:     "https://github.com/docker/datakit"
-bug-reports:  "https://github.com/docker/datakit/issues"
-dev-repo:     "https://github.com/docker/datakit.git"
+homepage:     "https://github.com/moby/datakit"
+bug-reports:  "https://github.com/moby/datakit/issues"
+dev-repo:     "https://github.com/moby/datakit.git"
 doc:          "https://docker.github.io/datakit/"
 
 build: [

--- a/datakit-github.opam
+++ b/datakit-github.opam
@@ -3,9 +3,9 @@ maintainer:   "thomas@gazagnaire.org"
 authors:      ["Thomas Leonard" "Magnus Skjegstad"
                "David Scott" "Thomas Gazagnaire"]
 license:      "Apache"
-homepage:     "https://github.com/docker/datakit"
-bug-reports:  "https://github.com/docker/datakit/issues"
-dev-repo:     "https://github.com/docker/datakit.git"
+homepage:     "https://github.com/moby/datakit"
+bug-reports:  "https://github.com/moby/datakit/issues"
+dev-repo:     "https://github.com/moby/datakit.git"
 doc:          "https://docker.github.io/datakit/"
 
 build: [

--- a/datakit-server.opam
+++ b/datakit-server.opam
@@ -3,9 +3,9 @@ maintainer:   "thomas@gazagnaire.org"
 authors:      ["Thomas Leonard" "Magnus Skjegstad"
                "David Scott" "Thomas Gazagnaire"]
 license:      "Apache"
-homepage:     "https://github.com/docker/datakit"
-bug-reports:  "https://github.com/docker/datakit/issues"
-dev-repo:     "https://github.com/docker/datakit.git"
+homepage:     "https://github.com/moby/datakit"
+bug-reports:  "https://github.com/moby/datakit/issues"
+dev-repo:     "https://github.com/moby/datakit.git"
 doc:          "https://docker.github.io/datakit/"
 
 build: [

--- a/datakit.opam
+++ b/datakit.opam
@@ -3,9 +3,9 @@ maintainer:   "thomas@gazagnaire.org"
 authors:      ["Thomas Leonard" "Magnus Skjegstad"
                "David Scott" "Thomas Gazagnaire"]
 license:      "Apache"
-homepage:     "https://github.com/docker/datakit"
-bug-reports:  "https://github.com/docker/datakit/issues"
-dev-repo:     "https://github.com/docker/datakit.git"
+homepage:     "https://github.com/moby/datakit"
+bug-reports:  "https://github.com/moby/datakit/issues"
+dev-repo:     "https://github.com/moby/datakit.git"
 doc:          "https://docker.github.io/datakit/"
 
 build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false"]

--- a/tests/test_client.ml
+++ b/tests/test_client.ml
@@ -611,7 +611,7 @@ let test_remove dk =
       >>*= fun () ->
 
       (* XXX: hack to make the test pass until we fix
-         https://github.com/docker/datakit/issues/147 *)
+         https://github.com/moby/datakit/issues/147 *)
       DK.Transaction.read_dir t (p "foo") >>*= fun _ ->
 
       DK.Transaction.remove t (p "foo/bar") >>*= fun () ->


### PR DESCRIPTION
`github.com/docker/datakit` -> `github.com/moby/datakit`

Docker Hub:

- `docker/datakit` -> `datakit/db`
- `docker/datakit:bridge-local-git` -> `datakit/local-bridge`
- `docker/datakit:github` -> `datakit/github-bridge`
- `docker/datakit:ci` -> `datakit/ci`

Signed-off-by: Thomas Leonard <thomas.leonard@docker.com>