### PR TITLE
datakit: update to latest versions of Irmin/Mirage/Cdmliner

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -1,12 +1,14 @@
 PKG lwt result fmt protocol-9p irmin cmdliner git
 PKG alcotest rresult github astring fmt irmin logs mtime.os
-PKG camlzip irmin.mem irmin-watcher
+PKG camlzip irmin-git irmin-watcher
 PKG conduit.lwt-unix hvsock named-pipe
 PKG asl win-eventlog github-hooks
 PKG datakit-client datakit-server.vfs datakit-github asetmap session.redis-lwt
 PKG prometheus-app
+PKG mirage-flow-lwt
 
 S src/**
-S tests/
+S tests/*
 S bridge/github/*
 B _build/**
+B _build/tests/

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,7 @@ COPY . /home/opam/src/datakit
 
 RUN sudo chown opam.nogroup -R /home/opam/src/datakit
 RUN cd /home/opam/src/datakit && \
-    git diff && git status --porcelain && \
-    git checkout . && scripts/watermark.sh && \
+    scripts/watermark.sh && \
     git status --porcelain
 
 RUN opam install datakit -ytv

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,14 @@
 #FROM ocaml/opam-dev:alpine-3.5_ocaml-4.04.0
-FROM ocaml/opam-dev@sha256:573b5d71e94104590a8282a9ae67b63a6144b15bafdacb9980391c84ca730615
+FROM ocaml/opam-dev@sha256:337fd0f78b182a12da3f66d9d5ca075dbb79df414fc01d6a0aee99ffeb35552a
 ENV OPAMERRLOGLEN=0 OPAMYES=1
 RUN sudo apk add tzdata aspcud gmp-dev perl
 
-RUN opam pin add -yn protocol-9p.0.8.0 'https://github.com/talex5/ocaml-9p.git#ping'
-RUN opam depext -ui lwt inotify alcotest conf-libev lambda-term asl win-eventlog camlzip irmin-watcher mtime mirage-flow conduit hvsock cohttp prometheus-app git.1.9.3 mirage-tc irmin.0.12.0 cmdliner.0.9.8 protocol-9p channel rresult win-error named-pipe
+RUN opam pin add hvsock.0.14.0 -n https://github.com/mirage/ocaml-hvsock.git#88397c37a910c61507a9655ed8413c1692294da0
+RUN opam pin add irmin.1.1.0 -n https://github.com/mirage/irmin.git#89196ad17c53b02f333022a87ecc264ec8c06af0
+RUN opam pin add irmin-git.1.1.0 -n https://github.com/mirage/irmin.git#89196ad17c53b02f333022a87ecc264ec8c06af0
+RUN opam pin add -yn protocol-9p.0.9.0 'https://github.com/talex5/ocaml-9p.git#ping-mirage-3'
+
+RUN opam depext -ui lwt inotify alcotest conf-libev lambda-term asl win-eventlog camlzip irmin-watcher mtime mirage-flow conduit hvsock cohttp prometheus-app git irmin cmdliner protocol-9p channel rresult win-error named-pipe
 
 COPY check-libev.ml /tmp/check-libev.ml
 RUN opam config exec -- ocaml /tmp/check-libev.ml
@@ -29,6 +33,8 @@ RUN cd /home/opam/src/datakit && \
     scripts/watermark.sh && \
     git status --porcelain
 
+# FIXME: warkaround a bug in opam2
+RUN opam install datakit-client datakit-github alcotest
 RUN opam install datakit -ytv
 
 RUN sudo cp $(opam config exec -- which datakit) /usr/bin/datakit && \

--- a/Dockerfile.bridge-local-git
+++ b/Dockerfile.bridge-local-git
@@ -10,8 +10,7 @@ RUN opam depext datakit-bridge-local-git && opam install datakit-bridge-local-gi
 COPY . /home/opam/src/datakit/
 RUN sudo chown opam.nogroup -R /home/opam/src/datakit
 RUN cd /home/opam/src/datakit && \
-    git diff && git status --porcelain && \
-    git checkout . && scripts/watermark.sh && \
+    scripts/watermark.sh && \
     git status --porcelain
 
 RUN opam update datakit-bridge-local-git

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,5 +1,5 @@
 #FROM ocaml/opam-dev:alpine-3.5_ocaml-4.04.0
-FROM ocaml/opam-dev@sha256:573b5d71e94104590a8282a9ae67b63a6144b15bafdacb9980391c84ca730615
+FROM ocaml/opam-dev@sha256:337fd0f78b182a12da3f66d9d5ca075dbb79df414fc01d6a0aee99ffeb35552a
 ENV OPAMERRLOGLEN=0 OPAMYES=1
 RUN sudo apk add tzdata aspcud
 
@@ -10,6 +10,10 @@ ADD . /home/opam/datakit
 RUN sudo chown opam /home/opam/datakit
 RUN opam pin add -k git datakit-client.dev /home/opam/datakit -y
 RUN opam pin add -k git datakit-github.dev /home/opam/datakit -y
+
+# FIXME: workaround bug in opam2
+RUN opam install datakit irmin-unix alcotest
+
 RUN opam pin add -k git datakit-ci.dev /home/opam/datakit -yt
 
 VOLUME /secrets

--- a/Dockerfile.client
+++ b/Dockerfile.client
@@ -15,8 +15,7 @@ RUN opam depext datakit-client && \
 COPY . /home/opam/src/datakit
 RUN sudo chown opam.nogroup -R /home/opam/src/datakit
 RUN cd /home/opam/src/datakit && \
-    git diff && git status --porcelain && \
-    git checkout . && scripts/watermark.sh && \
+    scripts/watermark.sh && \
     git status --porcelain
 RUN opam update datakit-client
 RUN opam info datakit-client --raw

--- a/Dockerfile.github
+++ b/Dockerfile.github
@@ -23,8 +23,7 @@ RUN opam pin add datakit-server.dev /home/opam/src/datakit -yn && \
 COPY . /home/opam/src/datakit
 RUN sudo chown opam.nogroup -R /home/opam/src/datakit
 RUN cd /home/opam/src/datakit && \
-    git diff && git status --porcelain && \
-    git checkout . && scripts/watermark.sh && \
+    scripts/watermark.sh && \
     git status --porcelain
 
 RUN opam install datakit-bridge-github -ytv

--- a/Dockerfile.github
+++ b/Dockerfile.github
@@ -1,21 +1,27 @@
 #FROM ocaml/opam-dev:alpine-3.5_ocaml-4.04.0
-FROM ocaml/opam-dev@sha256:573b5d71e94104590a8282a9ae67b63a6144b15bafdacb9980391c84ca730615
+FROM ocaml/opam-dev@sha256:337fd0f78b182a12da3f66d9d5ca075dbb79df414fc01d6a0aee99ffeb35552a
 ENV OPAMERRLOGLEN=0 OPAMYES=1
 RUN sudo apk add tzdata aspcud
 
-RUN opam pin add -yn protocol-9p.0.8.0 'https://github.com/talex5/ocaml-9p.git#ping'
+RUN opam pin add hvsock.0.14.0 -n https://github.com/mirage/ocaml-hvsock.git#88397c37a910c61507a9655ed8413c1692294da0
+RUN opam pin add irmin.1.1.0 -n https://github.com/mirage/irmin.git#89196ad17c53b02f333022a87ecc264ec8c06af0
+RUN opam pin add irmin-git.1.1.0 -n https://github.com/mirage/irmin.git#89196ad17c53b02f333022a87ecc264ec8c06af0
+RUN opam pin add -yn protocol-9p.0.9.0 'https://github.com/talex5/ocaml-9p.git#ping-mirage-3'
 RUN opam pin add github --dev -n
-RUN opam depext -ui lwt inotify alcotest conf-libev lambda-term cmdliner.0.9.8 github protocol-9p rresult prometheus-app mirage-types-lwt.2.8.0 asl win-eventlog mtime hex github-hooks hvsock camlzip irmin-watcher datakit-server git mirage-tc irmin.0.12.0
+
+RUN opam depext -ui lwt inotify alcotest conf-libev lambda-term cmdliner github protocol-9p rresult prometheus-app asl win-eventlog mtime hex github-hooks hvsock camlzip irmin-watcher git irmin
 
 COPY check-libev.ml /tmp/check-libev.ml
 RUN opam config exec -- ocaml /tmp/check-libev.ml
 
 # cache opam install of dependencies
+COPY datakit.opam /home/opam/src/datakit/datakit.opam
 COPY datakit-client.opam /home/opam/src/datakit/datakit-client.opam
 COPY datakit-server.opam /home/opam/src/datakit/datakit-server.opam
 COPY datakit-github.opam /home/opam/src/datakit/datakit-github.opam
 COPY datakit-bridge-github.opam /home/opam/src/datakit/datakit-bridge-github.opam
-RUN opam pin add datakit-server.dev /home/opam/src/datakit -yn && \
+RUN opam pin add datakit.dev /home/opam/src/datakit -yn && \
+    opam pin add datakit-server.dev /home/opam/src/datakit -yn && \
     opam pin add datakit-client.dev /home/opam/src/datakit -yn && \
     opam pin add datakit-github.dev /home/opam/src/datakit -yn && \
     opam pin add datakit-bridge-github.dev /home/opam/src/datakit -yn
@@ -26,6 +32,8 @@ RUN cd /home/opam/src/datakit && \
     scripts/watermark.sh && \
     git status --porcelain
 
+# FIXME: workaround bug in opam2
+RUN opam install datakit
 RUN opam install datakit-bridge-github -ytv
 
 RUN sudo cp $(opam config exec -- which datakit-bridge-github) /usr/bin/

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ bridge-local-git:
 
 bridge-github:
 	ocaml pkg/pkg.ml build -n datakit-bridge-github -q --tests true
-	ocaml pkg/pkg.ml test
+	ocaml pkg/pkg.ml test -n datakit-bridge-github
 
 ci:
 	ocaml pkg/pkg.ml build -n datakit-ci -q --tests true

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ depends:
 
 datakit:
 	ocaml pkg/pkg.ml build --tests $(TESTS) -q
+	ocaml pkg/pkg.ml test
 
 client:
 	ocaml pkg/pkg.ml build -n datakit-client -q

--- a/_tags
+++ b/_tags
@@ -11,7 +11,7 @@ true: package(bytes lwt astring logs result cstruct fmt rresult)
 
 ### datakit-server
 
-<src/datakit-server/*>: package(protocol-9p.unix)
+<src/datakit-server/*>: package(protocol-9p.unix mirage-flow-lwt)
 
 ### datakit
 

--- a/_tags
+++ b/_tags
@@ -11,18 +11,18 @@ true: package(bytes lwt astring logs result cstruct fmt rresult)
 
 ### datakit-server
 
-<src/datakit-server/*>: package(protocol-9p.unix, mirage-types)
+<src/datakit-server/*>: package(protocol-9p.unix)
 
 ### datakit
 
-<src/datakit/ivfs*>: package(irmin tc datakit-server.vfs asetmap)
+<src/datakit/ivfs*>: package(irmin datakit-server.vfs asetmap)
 
 #### irmin-io
-<src/datakit_io.*>: package(conduit.lwt-unix irmin lwt.unix uri camlzip git tc)
+<src/datakit_io.*>: package(conduit.lwt-unix irmin lwt.unix uri camlzip git irmin-git)
 
 <src/datakit/*>: package(prometheus-app.unix)
 <src/datakit/main.*>: package(cmdliner fmt.cli fmt.tty logs.fmt asetmap)
-<src/datakit/main.*>: package(git irmin irmin.git irmin.mem irmin-watcher)
+<src/datakit/main.*>: package(git irmin irmin-git irmin-watcher)
 <src/datakit/main.*>: package(irmin-watcher), thread
 <src/datakit/main.*>: package(protocol-9p.unix camlzip)
 
@@ -37,8 +37,8 @@ true: package(bytes lwt astring logs result cstruct fmt rresult)
 ### Tests
 
 <tests/*>: package(alcotest conduit.lwt-unix str logs.fmt fmt.tty mtime.os)
-<tests/*>: package(mirage-types.lwt protocol-9p.unix irmin irmin.mem camlzip)
-<tests/*>: package(git irmin.git asetmap)
+<tests/*>: package(protocol-9p.unix irmin camlzip)
+<tests/*>: package(git irmin-git asetmap)
 <tests/*>: thread, package(conduit.lwt-unix hvsock.lwt-unix named-pipe.lwt)
 
 ### Painful

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,7 @@ environment:
   FORK_BRANCH: master
   CYG_ROOT: C:\cygwin64
   PACKAGE: datakit
+  PINS: "hvsock:https://github.com/mirage/ocaml-hvsock.git irmin.1.1.0:--dev irmin-git.1.1.0:--dev datakit-server.dev:."
 
 install:
   - ps: iex ((new-object net.webclient).DownloadString("https://raw.githubusercontent.com/$env:FORK_USER/ocaml-ci-scripts/$env:FORK_BRANCH/appveyor-install.ps1"))

--- a/circle.yml
+++ b/circle.yml
@@ -13,12 +13,16 @@ dependencies:
   cache_directories:
   - ~/.opam
   override:
+  - brew update && brew upgrade
   - brew install wget ocaml opam dylibbundler
   - opam init --comp system -n https://github.com/ocaml/opam-repository.git
   - opam switch system
-  - opam update && opam upgrade
+  - opam pin add hvsock --dev -n
+  - opam pin add irmin.1.1.0 --dev -n
+  - opam pin add irmin-git.1.1.0 --dev -n
   - opam pin add datakit-server.dev . -n
   - opam pin add datakit.dev . -n
+  - opam update && opam upgrade
   - opam install depext && opam depext osx-fsevents datakit
   - opam list
   - opam reinstall datakit-server datakit -v

--- a/datakit-bridge-github.opam
+++ b/datakit-bridge-github.opam
@@ -22,7 +22,7 @@ depends: [
   "ocamlbuild" {build}
   "topkg"      {build}
   "cmdliner"
-  "lwt" {>= "2.7.0"}
+  "lwt" {>= "2.7.1"}
   "datakit-github"
   "logs" "fmt" "mtime" "asl" "win-eventlog"
   "uri" {>= "1.8.0"}

--- a/datakit-bridge-github.opam
+++ b/datakit-bridge-github.opam
@@ -21,7 +21,7 @@ depends: [
   "ocamlfind"  {build}
   "ocamlbuild" {build}
   "topkg"      {build}
-  "cmdliner" {<"1.0.0"}
+  "cmdliner"
   "lwt" {>= "2.7.0"}
   "datakit-github"
   "logs" "fmt" "mtime" "asl" "win-eventlog"

--- a/datakit-bridge-github.opam
+++ b/datakit-bridge-github.opam
@@ -14,7 +14,7 @@ build: [
 
 build-test: [
   ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "-n" name "--tests" "true"]
-  ["ocaml" "pkg/pkg.ml" "test"]
+  ["ocaml" "pkg/pkg.ml" "test" "-n" name]
 ]
 
 depends: [

--- a/datakit-bridge-local-git.opam
+++ b/datakit-bridge-local-git.opam
@@ -15,7 +15,7 @@ depends: [
   "ocamlfind"  {build}
   "ocamlbuild" {build}
   "topkg"      {build}
-  "cmdliner" {< "1.0.0"}
+  "cmdliner"
   "irmin"    {< "1.0"}
   "irmin-watcher"
   "irmin-unix"

--- a/datakit-bridge-local-git.opam
+++ b/datakit-bridge-local-git.opam
@@ -19,7 +19,7 @@ depends: [
   "irmin"    {< "1.0"}
   "irmin-watcher"
   "irmin-unix"
-  "lwt" {>= "2.7.0"}
+  "lwt" {>= "2.7.1"}
   "logs" "fmt"
   "protocol-9p"    {>= "0.8.0"}
   "datakit-client" {>= "0.9.0"}

--- a/datakit-ci.opam
+++ b/datakit-ci.opam
@@ -24,7 +24,7 @@ depends: [
   "datakit-github" {>= "0.9.0"}
   "protocol-9p" {>= "0.8.0"}
   "astring"
-  "cmdliner" {<"1.0.0"}
+  "cmdliner"
   "fmt"
   "logs"
   "tyxml" {>= "4.0.0"}

--- a/datakit-ci.opam
+++ b/datakit-ci.opam
@@ -39,7 +39,7 @@ depends: [
   "asetmap"
   "github" {>= "2.2.0"}
   "prometheus-app"
-  "lwt" {>= "2.7.0"}
+  "lwt" {>= "2.7.1"}
   "ppx_sexp_conv" {build}
   "crunch" {build}
   "datakit" {test}

--- a/datakit-ci.opam
+++ b/datakit-ci.opam
@@ -14,7 +14,7 @@ build: [
 
 build-test: [
   ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true" "-n" name]
-  ["ocaml" "pkg/pkg.ml" "test"]
+  ["ocaml" "pkg/pkg.ml" "test" "-n" name]
 ]
 
 depends: [

--- a/datakit-github.opam
+++ b/datakit-github.opam
@@ -17,7 +17,7 @@ depends: [
   "ocamlbuild" {build}
   "topkg"      {build}
   "cmdliner"
-  "lwt" {>= "2.7.0"}
+  "lwt" {>= "2.7.1"}
   "uri" {>= "1.8.0"}
   "asetmap"
   "logs"

--- a/datakit-server.opam
+++ b/datakit-server.opam
@@ -19,7 +19,7 @@ depends: [
   "base-bytes"
   "astring" "logs" "uri" "rresult" "fmt"
   "cstruct" {>= "2.2.0"}
-  "protocol-9p" {>= "0.7.4" & < "0.9.0"}
+  "protocol-9p" {>= "0.9.0"}
   "mirage-flow-lwt"
   "sexplib"
   "prometheus"

--- a/datakit-server.opam
+++ b/datakit-server.opam
@@ -22,6 +22,5 @@ depends: [
   "protocol-9p" {>= "0.7.4" & < "0.9.0"}
   "sexplib"
   "prometheus"
-  "mirage-types-lwt" {< "3.0.0"}
-  "cmdliner" {< "1.0.0"}
+  "cmdliner"
 ]

--- a/datakit-server.opam
+++ b/datakit-server.opam
@@ -20,6 +20,7 @@ depends: [
   "astring" "logs" "uri" "rresult" "fmt"
   "cstruct" {>= "2.2.0"}
   "protocol-9p" {>= "0.7.4" & < "0.9.0"}
+  "mirage-flow-lwt"
   "sexplib"
   "prometheus"
   "cmdliner"

--- a/datakit.opam
+++ b/datakit.opam
@@ -22,7 +22,7 @@ depends: [
   "rresult" "astring" "fmt" "asetmap"
   "git"         {>= "1.9.3"}
   "uri"
-  "irmin"       {>= "1.0.0"}
+  "irmin"       {>= "1.1.0"}
   "irmin-git"   {>= "1.0.0"}
   "camlzip"     {>= "1.06"}
   "cstruct"     {>= "2.2"}

--- a/datakit.opam
+++ b/datakit.opam
@@ -18,12 +18,12 @@ depends: [
   "ocamlfind"  {build}
   "ocamlbuild" {build}
   "topkg"      {build}
-  "cmdliner"    {<"1.0.0"}
+  "cmdliner"
   "rresult" "astring" "fmt" "asetmap"
   "git"         {>= "1.9.3"}
-  "mirage-tc" "uri"
-  "mirage-types" {< "3.0.0"}
-  "irmin"       {>= "0.12.0" & < "1.0.0"}
+  "uri"
+  "irmin"       {>= "1.0.0"}
+  "irmin-git"   {>= "1.0.0"}
   "camlzip"     {>= "1.06"}
   "cstruct"     {>= "2.2"}
   "result"

--- a/datakit.opam
+++ b/datakit.opam
@@ -27,7 +27,7 @@ depends: [
   "camlzip"     {>= "1.06"}
   "cstruct"     {>= "2.2"}
   "result"
-  "lwt"         {>= "2.7.0"}
+  "lwt"         {>= "2.7.1"}
   "conduit" "mirage-flow"
   "named-pipe"  {>= "0.4.0"}
   "hvsock"      {>= "0.8.1"}

--- a/src/datakit-client/datakit_client_9p.ml
+++ b/src/datakit-client/datakit_client_9p.ml
@@ -785,7 +785,8 @@ module Make(P9p : Protocol_9p_client.S) = struct
          FS.write_stream t (path / "url") (Cstruct.of_string url) >>*= fun () ->
          FS.write_stream t (path / "fetch") (Cstruct.of_string branch) >>*= fun () ->
          FS.read_all t (path / "head") >>*= fun commit_id ->
-         ok { Commit.fs = t; id = Cstruct.to_string commit_id })
+         let id = String.trim (Cstruct.to_string commit_id) in
+         ok { Commit.fs = t; id })
       (fun () ->
          FS.remove t path >|= function
          | Error e ->

--- a/src/datakit-server/fs9p.ml
+++ b/src/datakit-server/fs9p.ml
@@ -188,7 +188,7 @@ module Op9p = struct
 
 end
 
-module Make (Flow: V1_LWT.FLOW) = struct
+module Make (Flow: Mirage_flow_lwt.S) = struct
 
   type flow = Flow.flow
 

--- a/src/datakit-server/fs9p.mli
+++ b/src/datakit-server/fs9p.mli
@@ -14,4 +14,4 @@ module type S = sig
 end
 
 (** Server builder. *)
-module Make (Flow: V1_LWT.FLOW): S with type flow = Flow.flow
+module Make (Flow: Mirage_flow_lwt.S): S with type flow = Flow.flow

--- a/src/datakit/ivfs.ml
+++ b/src/datakit/ivfs.ml
@@ -2,7 +2,7 @@ open Astring
 open Rresult
 open Lwt.Infix
 
-let src = Logs.Src.create "ivfs" ~doc:"Irmin VFS"
+let src = Logs.Src.create "DataKit" ~doc:"Irmin VFS for DataKit"
 module Log = (val Logs.src_log src : Logs.LOG)
 
 module PathSet = Ivfs_merge.PathSet

--- a/src/datakit/ivfs.ml
+++ b/src/datakit/ivfs.ml
@@ -454,7 +454,7 @@ module Make (Store : Ivfs_tree.S) = struct
 
     let snapshot store =
       Store.Head.find store >>= function
-      | None    -> Lwt.return (Store.Tree.empty (), [])
+      | None    -> Lwt.return (Store.Tree.empty, [])
       | Some id -> Store.Commit.tree id >|= fun tree -> (tree, [id])
 
     let store_of_hash repo hash =

--- a/src/datakit/ivfs.ml
+++ b/src/datakit/ivfs.ml
@@ -2,11 +2,14 @@ open Astring
 open Rresult
 open Lwt.Infix
 
+let src = Logs.Src.create "ivfs" ~doc:"Irmin VFS"
+module Log = (val Logs.src_log src : Logs.LOG)
+
 module PathSet = Ivfs_merge.PathSet
 
 module type S = sig
   type repo
-  val create: string Irmin.Task.f -> repo -> Vfs.Dir.t
+  val create: info:(string -> Irmin.Info.t) -> repo -> Vfs.Dir.t
 end
 
 let ( >>*= ) x f =
@@ -21,54 +24,68 @@ let err_not_dir = Lwt.return Vfs.Error.not_dir
 let err_read_only = Lwt.return Vfs.Error.read_only_file
 let err_conflict msg = Vfs.error "Merge conflict: %s" msg
 let err_unknown_cmd x = Vfs.error "Unknown command %S" x
-let err_invalid_commit_id id = Vfs.error "Invalid commit ID %S" id
 let err_invalid_hash h x =
   Vfs.error "invalid-hash %S: %s" h (Printexc.to_string x)
 let err_not_fast_forward = Vfs.error "not-fast-forward"
 
-module Make (Store : Ivfs_tree.STORE) = struct
+module Make (Store : Ivfs_tree.S) = struct
 
   type repo = Store.Repo.t
   let empty_inode_map: Vfs.Inode.t String.Map.t = String.Map.empty
 
-  module Path = Ivfs_tree.Path
-  module Tree = Ivfs_tree.Make(Store)
-  module RW = Ivfs_rw.Make(Tree)
+  module Path = Store.Key
+  module RW = Ivfs_rw.Make(Store)
   module Merge = Ivfs_merge.Make(Store)(RW)
   module Remote = Ivfs_remote.Make(Store)
 
-  let string_of_commit_ids ids =
+  let commit_of_commit_id repo name =
+    match Store.Commit.Hash.of_string name with
+    | Error (`Msg e) -> err_invalid_hash name (Failure e)
+    | Ok hash        ->
+      Store.Commit.of_hash repo hash >>= function
+      | None      -> err_no_entry
+      | Some hash -> ok hash
+
+  let string_of_commits ids =
     ids
-    |> List.map (fun h -> Store.Hash.to_hum h ^ "\n")
+    |> List.map (fun h -> Fmt.strf "%a\n" Store.Commit.pp h)
     |> String.concat ~sep:""
 
-  module CommitListFile : sig
+    module CommitListFile : sig
     type t
-    val make : Store.Hash.t list -> t
+    val make : Store.Repo.t -> Store.Commit.t list -> t
     val file : t -> Vfs.File.t
-    val read : t -> (Store.Hash.t list, string) result Lwt.t
-    val append : t -> Store.Hash.t -> unit Vfs.or_err
+    val read : t -> (Store.Commit.t list, Vfs.Error.t) result Lwt.t
+    val append : t -> Store.Commit.t -> unit Vfs.or_err
   end = struct
     type t = {
+      repo : Store.Repo.t;
       file : Vfs.File.t;
-      get : unit -> string;
+      get  : unit -> string;
     }
 
-    let make init =
-      let init = string_of_commit_ids init in
+    let make repo init =
+      let init = string_of_commits init in
       let file, get = Vfs.File.rw_of_string init in
-      { file; get }
+      { repo; file; get }
 
     let file t = t.file
 
     let read t =
       let lines = String.cuts ~empty:false ~sep:"\n" (t.get ()) in
-      match List.map Store.Hash.of_hum lines with
-      | exception Invalid_argument msg -> Lwt.return (Error msg)
-      | hashes -> Lwt.return (Ok hashes)
+      Lwt_list.fold_left_s (fun acc line ->
+          match acc with
+          | Error _ -> Lwt.return acc
+          | Ok acc  ->
+            commit_of_commit_id t.repo line >|= function
+            | Error _ as e -> e
+            | Ok commit    -> Ok (commit :: acc)
+        ) (Ok []) (List.rev lines)
 
-    let append t commit_id =
-      let data = Cstruct.of_string (Store.Hash.to_hum commit_id ^ "\n") in
+    let append t commit =
+      let data =
+        Fmt.kstrf (fun x -> Cstruct.of_string x) "%a\n" Store.Commit.pp commit
+      in
       Vfs.File.size t.file >>*= fun size ->
       Vfs.File.open_ t.file >>*= fun fd ->
       Vfs.File.write fd ~offset:size data
@@ -79,8 +96,8 @@ module Make (Store : Ivfs_tree.STORE) = struct
     val make : unit -> t
     val add_all : t -> PathSet.t -> unit
     val read : t -> PathSet.t
-    val remove_file : t -> Ivfs_tree.Path.t -> unit
-    val remove_subtree : t -> Ivfs_tree.Path.t -> unit
+    val remove_file : t -> Store.Key.t -> unit
+    val remove_subtree : t -> Store.Key.t -> unit
     val file : t -> Vfs.File.t
   end = struct
     type t = PathSet.t ref
@@ -89,7 +106,7 @@ module Make (Store : Ivfs_tree.STORE) = struct
       let lines =
         conflicts
         |> PathSet.elements
-        |> List.map (fun p -> Path.to_hum p ^ "\n")
+        |> List.map (fun p -> Fmt.strf "%a\n" Store.Key.pp p)
       in
       Cstruct.of_string (String.concat ~sep:"" lines)
 
@@ -123,26 +140,25 @@ module Make (Store : Ivfs_tree.STORE) = struct
   let empty_file = Ivfs_blob.empty
 
   let stat path root =
-    Tree.Dir.lookup_path root path >>= function
-    | `None         -> err_no_entry
-    | `Directory _  -> err_is_dir
-    | `File (f, (`Normal | `Exec as perm)) ->
-      Tree.File.size f >|= fun length ->
-      Ok {Vfs.length; perm}
-    | `File (f, `Link) ->
-      Tree.File.content f >>= fun target ->
-      Tree.File.size f >|= fun length ->
-      Ok {Vfs.length; perm = `Link (Ivfs_blob.to_string target)}
+    Store.Tree.find_tree root path >>= function
+    | None -> err_no_entry
+    | Some (`Node _) -> err_is_dir
+    | Some (`Contents (f, (`Normal | `Exec as perm))) ->
+      let length = Ivfs_blob.len f in
+      ok {Vfs.length; perm}
+    | Some (`Contents (f, `Link)) ->
+      let length = Ivfs_blob.len f in
+      let target = Ivfs_blob.to_string f in
+      ok {Vfs.length; perm = `Link target}
 
   let irmin_ro_file ~get_root path =
     let read () =
       get_root () >>= fun root ->
-      Tree.Dir.lookup_path root path >>= function
-      | `None         -> Lwt.return (Ok None)
-      | `Directory _  -> err_is_dir
-      | `File (f, _perm) ->
-        Tree.File.content f >|= fun content ->
-        Ok (Some (Ivfs_blob.to_ro_cstruct content))
+      Store.Tree.find_tree root path >>= function
+      | None -> Lwt.return (Ok None)
+      | Some (`Node _) -> err_is_dir
+      | Some (`Contents (f, _perm)) ->
+        ok (Some (Ivfs_blob.to_ro_cstruct f))
     in
     let stat () = get_root () >>= stat path in
     Vfs.File.of_kvro ~read ~stat
@@ -153,10 +169,10 @@ module Make (Store : Ivfs_tree.STORE) = struct
     | Some (dir, leaf) ->
       let blob () =
         let root = RW.root view in
-        Tree.Dir.lookup_path root path >>= function
-        | `None         -> Lwt.return (Ok None)
-        | `Directory _  -> err_is_dir
-        | `File (f, _perm) -> Tree.File.content f >|= fun b -> Ok (Some b)
+        Store.Tree.find_tree root path >>= function
+        | None -> Lwt.return (Ok None)
+        | Some (`Node _) -> err_is_dir
+        | Some (`Contents (f, _perm)) -> ok (Some f)
       in
       let blob_or_empty () =
         blob () >>*= function
@@ -213,7 +229,7 @@ module Make (Store : Ivfs_tree.STORE) = struct
        same qid to the client each time. TODO: use a weak map here. *)
     let nodes = Hashtbl.create 10 in
 
-    let rec get ~dir (ty, leaf) =
+    let rec get ~dir (leaf, ty) =
       let hash_key = (ty, Path.rcons dir leaf) in
       try Hashtbl.find nodes hash_key
       with Not_found ->
@@ -223,8 +239,8 @@ module Make (Store : Ivfs_tree.STORE) = struct
 
     and inode_of (ty, full_path) =
       match ty with
-      | `Directory -> irmin_ro_dir full_path
-      | `File      ->
+      | `Node -> irmin_ro_dir full_path
+      | `Contents      ->
         let path = name_of_irmin_path full_path in
         let file = irmin_ro_file ~get_root full_path in
         Vfs.Inode.file path file
@@ -233,31 +249,31 @@ module Make (Store : Ivfs_tree.STORE) = struct
       let name = name_of_irmin_path path in
       let ls () =
         get_root () >>= fun root ->
-        Tree.Dir.get root path >>= function
-        | None -> err_no_entry
-        | Some dir ->
-          Tree.Dir.ls dir >>= fun items ->
+        Store.Tree.find_tree root path >>= function
+        | None | Some (`Contents _) -> err_no_entry
+        | Some (`Node _ as dir) ->
+          Store.Tree.list dir Store.Key.empty >>= fun items ->
           ok (List.map (get ~dir:path) items)
       in
       let lookup name =
         get_root () >>= fun root ->
-        Tree.Dir.get root path >>= function
-        | None -> err_no_entry
-        | Some dir ->
-          Tree.Dir.ty dir name >>= function
-          | `File
-          | `Directory as ty -> ok (get ~dir:path (ty, name))
-          | `None            -> err_no_entry
+        Store.Tree.find_tree root path >>= function
+        | None | Some (`Contents _) -> err_no_entry
+        | Some (`Node _ as dir) ->
+          let step = Store.Key.v [name] in
+          Store.Tree.kind dir step >>= function
+          | None -> err_no_entry
+          | Some (`Contents | `Node as ty) -> ok (get ~dir:path (name, ty))
       in
       let remove () = Vfs.Dir.err_read_only in
       Vfs.Dir.read_only ~ls ~lookup ~remove |> Vfs.Inode.dir name
     in
     irmin_ro_dir Path.empty
 
-  let read_only store = ro_tree ~get_root:(fun () -> Tree.snapshot store)
+  let read_only store = ro_tree ~get_root:(fun () -> Store.tree store)
 
   let remove_shadowed_by items map =
-    List.fold_left (fun acc (_, name) ->
+    List.fold_left (fun acc (name, _) ->
         String.Map.remove name acc
       ) map items
 
@@ -269,7 +285,7 @@ module Make (Store : Ivfs_tree.STORE) = struct
        same qid to the client each time. TODO: use a weak map here. *)
     let nodes = Hashtbl.create 10 in
 
-    let rec get ~dir (ty, leaf) =
+    let rec get ~dir (leaf, ty) =
       let hash_key = (ty, Path.rcons dir leaf) in
       try Hashtbl.find nodes hash_key
       with Not_found ->
@@ -279,8 +295,8 @@ module Make (Store : Ivfs_tree.STORE) = struct
 
     and inode_of (ty, full_path) =
       match ty with
-      | `Directory -> irmin_rw_dir full_path
-      | `File ->
+      | `Node -> irmin_rw_dir full_path
+      | `Contents ->
         let path = name_of_irmin_path full_path in
         let file = irmin_rw_file ~remove_conflict ~view full_path in
         Vfs.Inode.file path file
@@ -292,9 +308,9 @@ module Make (Store : Ivfs_tree.STORE) = struct
       let extra_dirs = ref empty_inode_map in
       let ls () =
         let root = RW.root view in
-        begin Tree.Dir.get root path >>= function
-          | None     -> Lwt.return []   (* in parent's extra_dirs? *)
-          | Some dir -> Tree.Dir.ls dir
+        begin Store.Tree.find_tree root path >>= function
+          | None | Some (`Contents _) -> Lwt.return [] (* in parent's extra_dirs? *)
+          | Some (`Node _ as dir) -> Store.Tree.list dir Store.Key.empty
         end >>= fun items ->
         extra_dirs := remove_shadowed_by items !extra_dirs;
         let extra_inodes = String.Map.bindings !extra_dirs |> List.map snd in
@@ -310,18 +326,18 @@ module Make (Store : Ivfs_tree.STORE) = struct
         | Ok () ->
           let new_path = Path.rcons path name in
           remove_conflict new_path;
-          Lwt.return (Ok (get ~dir:path (`File, name)))
+          Lwt.return (Ok (get ~dir:path (name, `Contents)))
       in
       let lookup name =
         let real_result =
           let snapshot = RW.root view in
-          Tree.Dir.get snapshot path >>= function
-          | None -> err_no_entry
-          | Some dir ->
-            Tree.Dir.ty dir name >>= function
-            | `File
-            | `Directory as ty -> ok (get ~dir:path (ty, name))
-            | `None            -> err_no_entry
+          Store.Tree.find_tree snapshot path >>= function
+          | None | Some (`Contents _) -> err_no_entry
+          | Some (`Node _ as dir) ->
+            let step = Store.Key.v [name] in
+            Store.Tree.kind dir step >>= function
+            | Some (`Contents | `Node as ty) -> ok (get ~dir:path (name, ty))
+            | None -> err_no_entry
         in
         real_result >|= function
         | Ok _ as ok   -> ok
@@ -334,7 +350,7 @@ module Make (Store : Ivfs_tree.STORE) = struct
         lookup name >>= function
         | Ok _    -> Vfs.Dir.err_already_exists
         | Error _ ->
-          let new_dir = get ~dir:path (`Directory, name) in
+          let new_dir = get ~dir:path (name, `Node) in
           extra_dirs := String.Map.add name new_dir !extra_dirs;
           remove_conflict (Path.rcons path name);
           ok new_dir
@@ -374,7 +390,7 @@ module Make (Store : Ivfs_tree.STORE) = struct
     irmin_rw_dir Path.empty
 
   module Diff : sig
-    val vfs_dir : (unit -> Tree.Dir.t Lwt.t) -> Vfs.Dir.t
+    val vfs_dir : Store.Repo.t -> (unit -> Store.tree Lwt.t) -> Vfs.Dir.t
     (* [vfs_dir head] is directory that provides diffs against [head ()]. *)
   end = struct
     let pp_op ppf = function
@@ -383,21 +399,20 @@ module Make (Store : Ivfs_tree.STORE) = struct
       | `Updated _ -> Fmt.string ppf "*"
 
     let pp_diff ppf (path, op) =
-      let path = Path.to_hum path in
+      let path = Fmt.to_to_string Store.Key.pp path in
       let path =
         if Filename.is_relative path then path
         else String.with_index_range ~first:1 path
       in
       Fmt.pf ppf "%a %s\n" pp_op op path
 
-    let vfs_dir head =
+    let vfs_dir repo head =
       let lookup name =
-        head () >>= fun head_t ->
-        let repo = Tree.Dir.repo head_t in
-        let hash = Store.Hash.of_hum name in
-        Store.of_commit_id Irmin.Task.none hash repo >>= fun t ->
-        Tree.snapshot (t ()) >>= fun parent_t ->
-        Tree.Dir.diff parent_t head_t >>= fun diff ->
+        head () >>= fun head ->
+        commit_of_commit_id repo name >>*= fun commit ->
+        Store.of_commit commit >>= fun t ->
+        Store.tree t >>= fun parent_t ->
+        Store.Tree.diff parent_t head >>= fun diff ->
         let lines = List.map (Fmt.to_to_string pp_diff) diff in
         let file  = Vfs.File.ro_of_string (String.concat ~sep:"" lines) in
         ok (Vfs.Inode.file name file)
@@ -408,25 +423,21 @@ module Make (Store : Ivfs_tree.STORE) = struct
   end
 
   module Transaction : sig
-    val make : (string -> Store.t) -> remover:unit Lwt.t Lazy.t -> Vfs.Dir.t Lwt.t
-    (* [make store ~remover] is a directory for making a transaction on [store].
-       When done, it will force [remover] (which should remove the directory). *)
+    val make :
+      Store.t -> info:(string -> Irmin.Info.t) -> remover:unit Lwt.t Lazy.t ->
+      Vfs.Dir.t Lwt.t
+    (* [make store ~info ~remover] is a directory for making a
+       transaction on [store].  When done, it will force [remover]
+       (which should remove the directory). *)
   end = struct
     type t = {
-      store : string -> Store.t;        (* The branch we're going to commit on *)
-      view : RW.t;                      (* The read/write directory with the current state *)
+      repo : Store.Repo.t;
+      store : Store.t;                 (* The branch we're going to commit on *)
+      view : RW.t;         (* The read/write directory with the current state *)
       get_msg : unit -> string;
       parents : CommitListFile.t;
       conflicts : PathSetFile.t;
     }
-
-    let make_commit root task ~parents =
-      let repo = Tree.Dir.repo root in
-      Tree.Dir.hash root >>= fun node ->
-      let commit = Store.Private.Commit.Val.create task ~parents ~node in
-      Store.Private.Commit.add (Store.Private.Repo.commit_t repo) commit
-
-    let unit_task () = Irmin.Task.empty
 
     let base ~our_parents ~ours ~their_commit =
       match our_parents with
@@ -436,36 +447,22 @@ module Make (Store : Ivfs_tree.STORE) = struct
            would have to explore the entire history to check). *)
         Lwt.return None
       | _ ->
-        Store.lcas_head ours ~n:1 their_commit >>= function
-        | `Max_depth_reached | `Too_many_lcas -> assert false
-        | `Ok [] -> Lwt.return None
-        | `Ok (base::_) ->
-          let repo = Store.repo ours in
-          Store.of_commit_id unit_task base repo >|= fun s ->
-          Some (s ())
+        Store.lcas_with_commit ours ~n:1 their_commit >>= function
+        | Error (`Max_depth_reached | `Too_many_lcas) -> assert false
+        | Ok []        -> Lwt.return None
+        | Ok (base::_) -> Store.of_commit base >|= fun s -> Some s
 
     let snapshot store =
-      let store1 = store "snapshot" in
-      let repo = Store.repo store1 in
-      Store.head store1 >>= fun orig_head ->
-      match orig_head with
-      | None -> Lwt.return (Tree.Dir.empty repo, [])
-      | Some id ->
-        Store.Private.Commit.read_exn (Store.Private.Repo.commit_t repo) id
-        >|= fun commit ->
-        Tree.Dir.of_hash repo (Store.Private.Commit.Val.node commit),
-        [id]
+      Store.Head.find store >>= function
+      | None    -> Lwt.return (Store.Tree.empty (), [])
+      | Some id -> Store.Commit.tree id >|= fun tree -> (tree, [id])
 
-    let store_of_hash repo commit_id =
-      match Store.Hash.of_hum commit_id with
-      | exception _  -> err_invalid_commit_id commit_id
-      | their_commit ->
-        Store.Private.Commit.mem (Store.Private.Repo.commit_t repo) their_commit
-        >>= function
-        | false -> err_no_entry
-        | true ->
-          Store.of_commit_id unit_task their_commit repo >>= fun store ->
-          Lwt.return (Ok (store, their_commit))
+    let store_of_hash repo hash =
+      commit_of_commit_id repo hash >>= function
+      | Error _ as e    -> Lwt.return e
+      | Ok their_commit ->
+        Store.of_commit their_commit >|= fun store ->
+        Ok (store, their_commit)
 
     let base_dir lca =
       match lca with
@@ -475,46 +472,53 @@ module Make (Store : Ivfs_tree.STORE) = struct
     let check_no_conflicts conflicts =
       match PathSetFile.read conflicts with
       | e when not (PathSet.is_empty e) ->
-        Lwt.return (Error "conflicts file is not empty")
-      | _ -> Lwt.return (Ok ())
+        Vfs.error "conflicts file is not empty"
+      | _ -> ok ()
 
     (* Make a commit based on "rw", "parents" and "msg" *)
-    let commit_of_view t =
+    let commit_of_view ~info t =
       check_no_conflicts t.conflicts >>*= fun () ->
       CommitListFile.read t.parents >>*= fun parents ->
       let msg = match t.get_msg () with
         | "" -> "(no commit message)"
         | x -> x
       in
-      let store = t.store msg in
       let root = RW.root t.view in
-      make_commit root (Store.task store) ~parents >|= fun c ->
+      Store.Commit.v t.repo ~info:(info msg) ~parents root >|= fun c ->
       Ok (c, "Merge", parents)
 
     (* Commit transaction *)
-    let merge t =
-      commit_of_view t >>*= fun (head, msg, _parents) ->
-      Store.merge_head (t.store msg) head >|= fun x -> Ok x
+    let merge ~info t =
+      commit_of_view ~info t >>= function
+      | Error e -> Lwt.return (Error (`Vfs e))
+      | Ok (head, msg, _parents) ->
+        (* FIXME(samoht): why do we reuse the same commit message here? *)
+        Store.Head.merge ~info:(fun () -> info msg) ~into:t.store head
+        >|= function
+        | Error (`Conflict _) as e -> e
+        | Ok () -> Ok ()
 
-    let transactions_ctl t ~remover = function
+    let transactions_ctl ~info t ~remover = function
       | "close" -> Lazy.force remover >|= fun () -> Ok ""
       | "commit" ->
-        begin merge t >>= function
-          | Ok (`Ok ())        -> Lazy.force remover >|= fun () -> Ok ""
-          | Ok (`Conflict msg) -> err_conflict msg
-          | Error ename        -> Vfs.error "%s" ename
+        begin merge ~info t >>= function
+          | Ok ()                 -> Lazy.force remover >|= fun () -> Ok ""
+          | Error (`Conflict msg) -> err_conflict msg
+          | Error (`Vfs err)      -> Lwt.return (Error err)
         end
       | x -> err_unknown_cmd x
 
-    let make store ~remover =
+    let make store ~info ~remover =
       let path = Path.empty in
       let msg_file, get_msg = Vfs.File.rw_of_string "" in
       snapshot store >>= fun (orig_root, parents) ->
+      let repo = Store.repo store in
       let t = {
+        repo;
         store;
-        view = RW.of_dir orig_root;
+        view = RW.of_dir repo orig_root;
         get_msg;
-        parents = CommitListFile.make parents;
+        parents = CommitListFile.make repo parents;
         conflicts = PathSetFile.make ();
       } in
       (* Current state (will finish initialisation below) *)
@@ -522,9 +526,9 @@ module Make (Store : Ivfs_tree.STORE) = struct
       (* Files present in both normal and merge modes *)
       let stage = rw ~conflicts:t.conflicts t.view in
       let add inode = String.Map.add (Vfs.Inode.basename inode) inode in
-      let ctl = Vfs.File.command (transactions_ctl t ~remover) in
-      let origin = Vfs.File.ro_of_string (Path.to_hum path) in
-      let diff = Diff.vfs_dir (fun  () -> Lwt.return (RW.root t.view)) in
+      let ctl = Vfs.File.command (transactions_ctl t ~info ~remover) in
+      let origin = Vfs.File.ro_of_string (Fmt.to_to_string Store.Key.pp path) in
+      let diff = Diff.vfs_dir repo (fun  () -> Lwt.return (RW.root t.view)) in
       let common =
         empty_inode_map
         |> add stage
@@ -536,32 +540,27 @@ module Make (Store : Ivfs_tree.STORE) = struct
       in
       (* Merge mode *)
       let rec merge_mode commit_id =
-        let store = store "merge" in
         let repo = Store.repo store in
         store_of_hash repo commit_id >>*= fun (theirs, their_commit) ->
-        let theirs = theirs () in
         (* Grab current "rw" dir as "ours" *)
-        commit_of_view t >>= function
-        | Error e -> Vfs.error "Can't start merge: %s" e
-        | Ok (our_commit, _msg, our_parents) ->
-          Store.of_commit_id unit_task our_commit repo >>= fun ours ->
-          let ours = ours () in
-          let ours_ro = read_only ~name:"ours" ours in
-          let theirs_ro = read_only ~name:"theirs" theirs in
-          base ~our_parents ~ours ~their_commit >>= fun base ->
-          (* Add to parents *)
-          CommitListFile.append t.parents their_commit >>*= fun () ->
-          (* Do the merge *)
-          Merge.merge ~ours ~theirs ~base t.view >>= fun merge_conflicts ->
-          PathSetFile.add_all t.conflicts merge_conflicts;
-          contents :=
-            common
-            |> add (Vfs.Inode.file "merge" (Vfs.File.command merge_mode))
-            |> add (Vfs.Inode.file "conflicts" (PathSetFile.file t.conflicts))
-            |> add ours_ro
-            |> add (base_dir base)
-            |> add theirs_ro;
-          Lwt.return (Ok "ok")
+        commit_of_view ~info t >>*= fun (our_commit, _msg, our_parents) ->
+        Store.of_commit our_commit >>= fun ours ->
+        let ours_ro = read_only ~name:"ours" ours in
+        let theirs_ro = read_only ~name:"theirs" theirs in
+        base ~our_parents ~ours ~their_commit >>= fun base ->
+        (* Add to parents *)
+        CommitListFile.append t.parents their_commit >>*= fun () ->
+        (* Do the merge *)
+        Merge.merge ~ours ~theirs ~base t.view >>= fun merge_conflicts ->
+        PathSetFile.add_all t.conflicts merge_conflicts;
+        contents :=
+          common
+          |> add (Vfs.Inode.file "merge" (Vfs.File.command merge_mode))
+          |> add (Vfs.Inode.file "conflicts" (PathSetFile.file t.conflicts))
+          |> add ours_ro
+          |> add (base_dir base)
+          |> add theirs_ro;
+        Lwt.return (Ok "ok")
       in
       let normal_mode () =
         common
@@ -576,19 +575,19 @@ module Make (Store : Ivfs_tree.STORE) = struct
   let head_stream store initial_head =
     let session = Vfs.File.Stream.session initial_head in
     let remove_watch =
-      let cb _ = Store.head store >|= Vfs.File.Stream.publish session in
-      Store.watch_head store ?init:initial_head cb
+      let cb _ = Store.Head.find store >|= Vfs.File.Stream.publish session in
+      Store.watch store ?init:initial_head cb
     in
     let pp ppf = function
       | None      -> Fmt.string ppf "\n"
-      | Some hash -> Fmt.string ppf (Store.Hash.to_hum hash ^ "\n")
+      | Some hash -> Fmt.pf ppf "%a\n" Store.Commit.pp hash
     in
     ignore remove_watch; (* TODO *)
     Vfs.File.Stream.create pp session
 
   let head_live store =
     Vfs.File.of_stream (fun () ->
-        Store.head store >|= fun initial_head ->
+        Store.Head.find store >|= fun initial_head ->
         head_stream store initial_head
       )
 
@@ -599,10 +598,10 @@ module Make (Store : Ivfs_tree.STORE) = struct
         | `Added x | `Updated (_, x) -> Vfs.File.Stream.publish session (Some x)
         | `Removed _                 -> Vfs.File.Stream.publish session None
       in
-      Store.watch_head store (fun x -> Lwt.return @@ cb x)
+      Store.watch store (fun x -> Lwt.return @@ cb x)
     in
     let pp ppf = function
-      | Some x -> Fmt.pf ppf "%s\n" (Store.Hash.to_hum x)
+      | Some x -> Fmt.pf ppf "%a\n" Store.Commit.pp x
       | None   -> Fmt.string ppf "\n"
     in
     ignore remove_watch; (* TODO *)
@@ -612,15 +611,22 @@ module Make (Store : Ivfs_tree.STORE) = struct
     Vfs.File.of_stream (fun () -> Lwt.return (reflog_stream store))
 
   let hash_line store path =
-    Tree.snapshot store >>= fun snapshot ->
-    Tree.Dir.lookup_path snapshot path >>= function
-    | `None              -> Lwt.return "\n"
-    | `File (f, `Normal) -> Tree.File.hash f >|= Fmt.strf "F-%a\n" Tree.File.pp_hash
-    | `File (f, `Exec)   -> Tree.File.hash f >|= Fmt.strf "X-%a\n" Tree.File.pp_hash
-    | `File (f, `Link)   -> Tree.File.hash f >|= Fmt.strf "L-%a\n" Tree.File.pp_hash
-    | `Directory dir ->
-      Tree.Dir.hash dir >|= fun h ->
-      Fmt.strf "D-%s\n" @@ Store.Private.Node.Key.to_hum h
+    Store.tree store >>= fun snapshot ->
+    Log.debug (fun x -> x "hash_line snapshot=%a path=%a"
+                  (Irmin.Type.pp_json Store.tree_t) snapshot
+                  (Irmin.Type.pp_json Store.key_t) path);
+    (* FIXME: `hash` is probably slow as there is no caching *)
+    let repo = Store.repo store in
+    let hash = Store.Contents.hash repo in
+    let pp_hash = Store.Contents.Hash.pp in
+    Store.Tree.find_tree snapshot path >>= function
+    | None                          -> Lwt.return "\n"
+    | Some (`Contents (f, `Normal)) -> hash f >|= Fmt.strf "F-%a\n" pp_hash
+    | Some (`Contents (f, `Exec))   -> hash f >|= Fmt.strf "X-%a\n" pp_hash
+    | Some (`Contents (f, `Link))   -> hash f >|= Fmt.strf "L-%a\n" pp_hash
+    | Some (`Node _ as dir) ->
+      Store.Tree.hash repo dir >|= fun h ->
+      Fmt.strf "D-%a\n" Store.Tree.Hash.pp h
 
   let watch_tree_stream store ~path ~init =
     let session = Vfs.File.Stream.session init in
@@ -632,7 +638,7 @@ module Make (Store : Ivfs_tree.STORE) = struct
           current := line;
           Vfs.File.Stream.publish session !current
         ) in
-      Store.watch_head store cb
+      Store.watch store cb
     in
     ignore remove_watch; (* TODO *)
     Vfs.File.Stream.create Fmt.string session
@@ -656,10 +662,7 @@ module Make (Store : Ivfs_tree.STORE) = struct
         inode
     in
     let ls () =
-      let to_inode x =
-        match Path.rdecons x with
-        | None -> assert false
-        | Some (_, name) -> lookup name in
+      let to_inode (x, _) = lookup x in
       Store.list store path >|= fun items ->
       Ok (Lazy.force live :: List.map to_inode items)
     in
@@ -674,43 +677,38 @@ module Make (Store : Ivfs_tree.STORE) = struct
 
   (* Note: can't use [Store.fast_forward_head] because it can
      sometimes return [false] on success (when already up-to-date). *)
-  let fast_forward store commit_id =
-    let store = store "Fast-forward" in
-    Store.head store >>= fun old_head ->
+  let fast_forward store commit =
+    Store.Head.find store >>= fun old_head ->
     let do_ff () =
-      Store.compare_and_set_head store ~test:old_head ~set:(Some commit_id) >|= function
-      | true -> `Ok
-      | false -> `Not_fast_forward in   (* (concurrent update) *)
+      Store.Head.test_and_set store ~test:old_head ~set:(Some commit)
+      >|= function
+      | true  -> `Ok
+      | false -> `Not_fast_forward  (* (concurrent update) *)
+    in
     match old_head with
     | None -> do_ff ()
     | Some expected ->
-      Store.lcas_head store commit_id >>= function
-      | `Ok lcas ->
+      Store.lcas_with_commit store commit >>= function
+      | Ok lcas ->
         if List.mem expected lcas then do_ff ()
         else Lwt.return `Not_fast_forward
       (* These shouldn't happen, because we didn't set any limits *)
-      | `Max_depth_reached | `Too_many_lcas -> assert false
+      | Error (`Max_depth_reached | `Too_many_lcas) -> assert false
 
   let fast_forward_merge store =
     Vfs.File.command (fun hash ->
-        match Store.Hash.of_hum hash with
-        | exception ex -> err_invalid_hash hash ex
-        | hash         ->
-          let commit_t = Store.Private.Repo.commit_t (Store.repo (store "commit_t")) in
-          Store.Private.Commit.mem commit_t hash >>= function
-          | false -> Vfs.error "Commit not in store"
-          | true ->
-            fast_forward store hash >>= function
-            | `Ok               -> ok ""
-            | `Not_fast_forward -> err_not_fast_forward
+        commit_of_commit_id (Store.repo store) hash >>*= fun hash ->
+        fast_forward store hash >>= function
+        | `Ok               -> ok ""
+        | `Not_fast_forward -> err_not_fast_forward
       )
 
   let status store () =
-    Store.head (store "head") >|= function
+    Store.Head.find store >|= function
     | None      -> "\n"
-    | Some head -> Store.Hash.to_hum head ^ "\n"
+    | Some head -> Fmt.strf "%a\n" Store.Commit.pp head
 
-  let transactions store =
+  let transactions ~info store =
     let lock = Lwt_mutex.create () in
     let items = ref String.Map.empty in
     let ls () = ok (String.Map.bindings !items |> List.map snd) in
@@ -730,7 +728,7 @@ module Make (Store : Ivfs_tree.STORE) = struct
           if String.Map.mem name !items then Vfs.Dir.err_already_exists
           else (
             let remover = remover name in
-            Transaction.make store ~remover >>= fun dir ->
+            Transaction.make store ~info ~remover >>= fun dir ->
             if Lazy.is_val remover then err_no_entry else (
               let inode = Vfs.Inode.dir name dir in
               items := String.Map.add name inode !items;
@@ -742,18 +740,18 @@ module Make (Store : Ivfs_tree.STORE) = struct
     let remove _ = Vfs.Dir.err_read_only in
     Vfs.Dir.create ~ls ~mkfile ~mkdir ~lookup ~remove ~rename
 
-  let branch make_task ~remove repo name =
+  let branch ~info ~remove repo name =
     let name = ref name in
     let remove () = remove !name in
     let make_contents name =
-      Store.of_branch_id make_task name repo >|= fun store ->
+      Store.of_branch repo name >|= fun store ->
       [
-        read_only ~name:"ro" (store "ro");
-        Vfs.Inode.dir  "transactions" (transactions store);
-        Vfs.Inode.dir  "watch"        (watch_dir ~path:Path.empty @@ store "watch");
-        Vfs.Inode.file "head.live"    (head_live @@ store "watch");
+        read_only ~name:"ro" store;
+        Vfs.Inode.dir  "transactions" (transactions ~info store);
+        Vfs.Inode.dir  "watch"        (watch_dir ~path:Path.empty store);
+        Vfs.Inode.file "head.live"    (head_live store);
         Vfs.Inode.file "fast-forward" (fast_forward_merge store);
-        Vfs.Inode.file "reflog"       (reflog @@ store "watch");
+        Vfs.Inode.file "reflog"       (reflog store);
         Vfs.Inode.file "head"         (Vfs.File.status (status store));
       ] in
     let contents = ref (make_contents !name) in
@@ -776,16 +774,17 @@ module Make (Store : Ivfs_tree.STORE) = struct
 
   module StringSet = Set.Make(String)
 
-  let branch_dir make_task repo =
+  let branch_dir ~info repo =
     let cache = ref String.Map.empty in
     let remove name =
-      Store.Repo.remove_branch repo name >|= fun () ->
+      Store.Branch.remove repo name >|= fun () ->
       cache := String.Map.remove name !cache;
-      Ok () in
+      Ok ()
+    in
     let get_via_cache name = match String.Map.find name !cache with
       | Some x -> x
       | None   ->
-        let entry = branch ~remove make_task repo name in
+        let entry = branch ~remove ~info repo name in
         cache :=  String.Map.add name entry !cache;
         entry
     in
@@ -804,7 +803,7 @@ module Make (Store : Ivfs_tree.STORE) = struct
     let lookup name = match String.Map.find name !cache with
       | Some (x, _) -> ok x
       | None        ->
-        Store.Private.Ref.mem (Store.Private.Repo.ref_t repo) name >>= function
+        Store.Branch.mem repo name >>= function
         | true  -> ok (get_via_cache name |> fst)
         | false -> err_no_entry
     in
@@ -813,16 +812,15 @@ module Make (Store : Ivfs_tree.STORE) = struct
     let rename inode new_name =
       (* TODO: some races here... *)
       let old_name = Vfs.Inode.basename inode in
-      let refs = Store.Private.Repo.ref_t repo in
-      Store.Private.Ref.mem refs new_name >>= function
+      Store.Branch.mem repo new_name >>= function
       | true -> err_is_dir
       | false ->
-        Store.Private.Ref.read refs old_name >>= fun head ->
+        Store.Branch.find repo old_name >>= fun head ->
         begin match head with
           | None      -> Lwt.return_unit
-          | Some head -> Store.Private.Ref.update refs new_name head end
-        >>= fun () ->
-        Store.Private.Ref.remove refs old_name >>= fun () ->
+          | Some head -> Store.Branch.set repo new_name head
+        end >>= fun () ->
+        Store.Branch.remove repo old_name >>= fun () ->
         match String.Map.find old_name !cache with
         | None      -> err_no_entry
         | Some entry ->
@@ -838,36 +836,46 @@ module Make (Store : Ivfs_tree.STORE) = struct
   (* /trees *)
 
   let tree_hash_of_hum h =
-    let file ty h = `File (ty, String.trim h |> Store.Private.Contents.Key.of_hum) in
-    let dir h = `Dir (String.trim h |> Store.Private.Node.Key.of_hum) in
-    try
-      match String.span ~min:2 ~max:2 h with
-      | "F-", hash -> Ok (file `Normal hash)
-      | "X-", hash -> Ok (file `Exec hash)
-      | "L-", hash -> Ok (file `Link hash)
-      | "D-", hash -> Ok (dir hash)
-      | _ -> Vfs.Error.no_entry
-    with _ex ->
-      Vfs.Error.no_entry
+    let file ty h =
+      let h = String.trim h in
+      match Store.Contents.Hash.of_string h with
+      | Error _ -> Vfs.Error.no_entry
+      | Ok hash -> Ok (`Contents (hash, ty))
+    in
+    let dir h =
+      let h = String.trim h in
+      match Store.Tree.Hash.of_string h with
+      | Error _ -> Vfs.Error.no_entry
+      | Ok hash -> Ok (`Node hash)
+    in
+    match String.span ~min:2 ~max:2 h with
+    | "F-", hash -> file `Normal hash
+    | "X-", hash -> file `Exec hash
+    | "L-", hash -> file `Link hash
+    | "D-", hash -> dir hash
+    | _ -> Vfs.Error.no_entry
 
-  let trees_dir _make_task repo =
+  let trees_dir repo =
     let inode_of_tree_hash name =
       Lwt.return (tree_hash_of_hum name) >>*= function
-      | `File (ty, hash) ->
+      | `Contents (hash, ty) ->
         begin
-          Store.Private.Contents.read (Store.Private.Repo.contents_t repo) hash
-          >|= function
+          Store.Contents.of_hash repo hash >|= function
           | None      -> Vfs.Error.no_entry
           | Some data ->
+            let data = Ivfs_blob.to_string data in
             let perm =
               match ty with
               | `Normal | `Exec as perm -> perm
-              | `Link -> `Link data in
+              | `Link -> `Link data
+            in
             Ok (Vfs.File.ro_of_string ~perm data |> Vfs.Inode.file name)
         end
-      | `Dir hash ->
-        let root = Tree.Dir.of_hash repo hash in
-        ok (ro_tree ~name:"ro" ~get_root:(fun () -> Lwt.return root))
+      | `Node hash ->
+        Store.Tree.of_hash repo hash >|= function
+        | None      -> Vfs.Error.no_entry
+        | Some data ->
+          Ok (ro_tree ~name:"ro" ~get_root:(fun () -> Lwt.return data))
     in
     let cache = ref String.Map.empty in   (* Could use a weak map here *)
     let ls () = ok [] in
@@ -885,64 +893,59 @@ module Make (Store : Ivfs_tree.STORE) = struct
 
   let parents_file store =
     let read () =
-      begin Store.head store >>= function
+      begin Store.Head.find store >>= function
         | None -> Lwt.return []
-        | Some head -> Store.history store ~depth:1 >|= fun hist ->
-          Store.History.pred hist head
+        | Some head ->
+          Store.history store ~depth:1 >|= fun hist ->
+          try Store.History.pred hist head
+          with Invalid_argument _ -> []
       end >|= fun parents ->
-      Ok (Some (Cstruct.of_string (string_of_commit_ids parents))) in
+      Ok (Some (Cstruct.of_string (string_of_commits parents)))
+    in
     Vfs.File.of_kvro ~read ~stat:(Vfs.File.stat_of ~read)
 
   let msg_file store commit_id =
     let read () =
       let repo = Store.repo store in
-      let id = Store.Private.Commit.Key.of_hum commit_id in
-      Store.Repo.task_of_commit_id repo id >|= fun task ->
-      let messages = Irmin.Task.messages task in
-      let msg = (String.concat ~sep:"\n" messages) ^ "\n" in
-      Ok (Some (Cstruct.of_string msg))
+      commit_of_commit_id repo commit_id >>*= fun commit ->
+      let info = Store.Commit.info commit in
+      let msg = Irmin.Info.message info ^ "\n" in
+      ok (Some (Cstruct.of_string msg))
     in
     Vfs.File.of_kvro ~read ~stat:(Vfs.File.stat_of ~read)
 
   let snapshot_dir store name =
-    let store = store "ro" in
+    let repo = Store.repo store in
     let dirs = Vfs.ok [
         read_only ~name:"ro"     store;
         Vfs.Inode.file "hash"    (Vfs.File.ro_of_string name);
         Vfs.Inode.file "msg"     (msg_file store name);
         Vfs.Inode.file "parents" (parents_file store);
-        Vfs.Inode.dir  "diff"    (Diff.vfs_dir (fun () -> Tree.snapshot store));
+        Vfs.Inode.dir  "diff"    (Diff.vfs_dir repo (fun () -> Store.tree store));
       ] in
     static_dir name (fun () -> dirs)
 
-  let snapshots_dir make_task repo =
+  let snapshots_dir repo =
     let cache = ref empty_inode_map in   (* Could use a weak map here *)
     let ls () = ok [] in
     let lookup name = match String.Map.find name !cache with
       | Some x ->  ok x
       | None   ->
-        begin
-          try ok (Store.Hash.of_hum name)
-          with _ex -> err_invalid_commit_id name
-        end >>*= fun commit_id ->
-        Store.Private.Commit.mem (Store.Private.Repo.commit_t repo) commit_id
-        >>= function
-        | false -> err_no_entry
-        | true  ->
-          Store.of_commit_id make_task commit_id repo >|= fun store ->
-          let inode = snapshot_dir store name in
-          cache := String.Map.add name inode !cache;
-          Ok inode
+        commit_of_commit_id repo name >>*= fun commit ->
+        Store.of_commit commit >|= fun store ->
+        let inode = snapshot_dir store name in
+        cache := String.Map.add name inode !cache;
+        Ok inode
     in
     let remove () = Vfs.Dir.err_read_only in
     Vfs.Dir.read_only ~ls ~lookup ~remove
 
-  let create make_task repo =
+  let create ~info repo =
     let dirs = Vfs.ok [
-        Vfs.Inode.dir "branch"     (branch_dir make_task repo);
-        Vfs.Inode.dir "trees"      (trees_dir make_task repo);
-        Vfs.Inode.dir "snapshots"  (snapshots_dir make_task repo);
-        Vfs.Inode.dir "remotes"    (Remote.create make_task repo);
+        Vfs.Inode.dir "branch"     (branch_dir ~info repo);
+        Vfs.Inode.dir "trees"      (trees_dir repo);
+        Vfs.Inode.dir "snapshots"  (snapshots_dir repo);
+        Vfs.Inode.dir "remotes"    (Remote.create repo);
         Vfs.Inode.dir "debug"      Vfs.Logs.dir;
       ] in
     Vfs.Dir.of_list (fun () -> dirs)

--- a/src/datakit/ivfs.mli
+++ b/src/datakit/ivfs.mli
@@ -6,11 +6,11 @@ module type S = sig
   type repo
   (** The type for repositories. *)
 
-  val create: string Irmin.Task.f -> repo -> Vfs.Dir.t
-  (** [create task repo] is the root directory of the filesystem for
-      the Irmin repository [repo]. [task] is used to create
-      timestamped commit messages for changes. *)
+  val create: info:(string -> Irmin.Info.t) -> repo -> Vfs.Dir.t
+  (** [create ~info repo] is the root directory of the filesystem for
+      the Irmin repository [repo]. [info] is used to create timestamped
+      commit messages for changes. *)
 
 end
 
-module Make (Store : Ivfs_tree.STORE): S with type repo = Store.Repo.t
+module Make (Store : Ivfs_tree.S): S with type repo = Store.Repo.t

--- a/src/datakit/ivfs_blob.ml
+++ b/src/datakit/ivfs_blob.ml
@@ -3,7 +3,7 @@ open Result
 type t = Cstruct.t list ref (* (reversed) *)
 
 let pp_buf ppf buf = Fmt.string ppf (Cstruct.to_string buf)
-let pp ppf t = Fmt.pf ppf "%a" Fmt.(list ~sep:(unit "") pp_buf) !t
+let pp ppf t = Fmt.pf ppf "%a" Fmt.(list ~sep:nop pp_buf) !t
 
 (* FIXME: very expensive! *)
 let compare x y =

--- a/src/datakit/ivfs_blob.ml
+++ b/src/datakit/ivfs_blob.ml
@@ -2,8 +2,8 @@ open Result
 
 type t = Cstruct.t list ref (* (reversed) *)
 
-let pp_buf ppf buf = Fmt.pf ppf "%S" (Cstruct.to_string buf)
-let pp ppf t = Fmt.pf ppf "%a" Fmt.(Dump.list pp_buf) !t
+let pp_buf ppf buf = Fmt.string ppf (Cstruct.to_string buf)
+let pp ppf t = Fmt.pf ppf "%a" Fmt.(list ~sep:(unit "") pp_buf) !t
 
 (* FIXME: very expensive! *)
 let compare x y =
@@ -27,6 +27,8 @@ let to_ro_cstruct t =
   let cs = Cstruct.concat (List.rev !t) in
   t := [cs];
   cs
+
+let t = Irmin.Type.(like cstruct) of_ro_cstruct to_ro_cstruct
 
 let to_string t =
   Cstruct.to_string (to_ro_cstruct t)

--- a/src/datakit/ivfs_blob.mli
+++ b/src/datakit/ivfs_blob.mli
@@ -6,6 +6,9 @@ open Result
 type t
 (** A [t] is an immutable sequence of bytes. *)
 
+val t: t Irmin.Type.t
+(** [t] is the value representing the type {!t}. *)
+
 val pp: t Fmt.t
 (** [pp] is the pretty-printer for blobs. *)
 

--- a/src/datakit/ivfs_merge.ml
+++ b/src/datakit/ivfs_merge.ml
@@ -1,9 +1,6 @@
 open Astring
 open Lwt.Infix
 
-let src = Logs.Src.create "DataKit.merge" ~doc:"Irmin VFS for DataKit"
-module Log = (val Logs.src_log src : Logs.LOG)
-
 type path = Ivfs_tree.path
 type step = Ivfs_tree.step
 
@@ -47,9 +44,8 @@ module Make (Store : Ivfs_tree.S) (RW : RW) = struct
       let f = Ivfs_blob.of_string (Printf.sprintf "** Conflict **\n%s\n" msg) in
       RW.update_force result path leaf (f, `Normal)
     in
-    let empty = Store.Tree.empty () in
     let as_dir = function
-      | None   -> empty
+      | None   -> Store.Tree.empty
       | Some v -> v
     in
     let rec merge_dir ~ours ~theirs ~base path =
@@ -96,7 +92,7 @@ module Make (Store : Ivfs_tree.S) (RW : RW) = struct
     Store.tree ours >>= fun ours ->
     Store.tree theirs >>= fun theirs ->
     begin match base with
-      | None      -> Lwt.return empty
+      | None      -> Lwt.return Store.Tree.empty
       | Some base -> Store.tree base
     end >>= fun base ->
     merge_dir ~ours ~theirs ~base Store.Key.empty >>= fun () ->

--- a/src/datakit/ivfs_merge.ml
+++ b/src/datakit/ivfs_merge.ml
@@ -1,7 +1,7 @@
 open Astring
 open Lwt.Infix
 
-let src = Logs.Src.create "ivfs.merge" ~doc:"Irmin VFS"
+let src = Logs.Src.create "DataKit.merge" ~doc:"Irmin VFS for DataKit"
 module Log = (val Logs.src_log src : Logs.LOG)
 
 type path = Ivfs_tree.path

--- a/src/datakit/ivfs_merge.mli
+++ b/src/datakit/ivfs_merge.mli
@@ -3,14 +3,13 @@ type step = Ivfs_tree.step
 
 module PathSet : Set.S with type elt = path
 
-
 module type RW = sig
   type t
   val update_force : t -> path -> step -> Ivfs_blob.t * Ivfs_tree.perm -> unit Lwt.t
   val remove_force : t -> path -> step -> unit Lwt.t
 end
 
-module Make (Store : Ivfs_tree.STORE) (RW : RW) : sig
+module Make (Store : Ivfs_tree.S) (RW : RW) : sig
   val merge :
     ours:Store.t ->
     theirs:Store.t ->

--- a/src/datakit/ivfs_remote.mli
+++ b/src/datakit/ivfs_remote.mli
@@ -1,7 +1,6 @@
-module Make (Store : Ivfs_tree.STORE): sig
+module Make (Store : Ivfs_tree.S): sig
 
-  val create: ?init:(string * string) list ->
-    string Irmin.Task.f -> Store.Repo.t -> Vfs.Dir.t
+  val create: ?init:(string * string) list -> Store.Repo.t -> Vfs.Dir.t
   (** Create the /remotes/ virtual directory. [init] is a pair of
       remote names and urls. *)
 

--- a/src/datakit/ivfs_rw.ml
+++ b/src/datakit/ivfs_rw.ml
@@ -1,11 +1,6 @@
 open Lwt.Infix
 open Result
 
-module Path = Ivfs_tree.Path
-
-type path = Path.t
-type step = Path.Step.t
-
 let ( >>*= ) x f =
   x >>= function
   | Ok y -> f y
@@ -17,15 +12,16 @@ let doesnt_fail = function
   | Ok x -> x
   | Error (_:impossible) -> assert false
 
-module Make (Tree : Ivfs_tree.S) = struct
+module Make (Store : Ivfs_tree.S) = struct
 
   type t = {
-    mutable root : Tree.Dir.t;
+    repo : Store.Repo.t;
+    mutable root : Store.tree;
     mutex : Lwt_mutex.t;
   }
 
-  let of_dir root = {
-    root;
+  let of_dir repo root = {
+    repo; root;
     mutex = Lwt_mutex.create ();
   }
 
@@ -35,89 +31,91 @@ module Make (Tree : Ivfs_tree.S) = struct
      [fn dir], then update all the parents back to the root. *)
   let update_dir ~file_on_path t path fn =
     Lwt_mutex.with_lock t.mutex @@ fun () ->
+    let empty = Store.Tree.empty () in
     let rec aux base path =
-      match Path.decons path with
+      match Store.Key.decons path with
       | None -> fn base
       | Some (p, ps) ->
-        begin Tree.Dir.lookup base p >>= function
-          | `None ->
-            aux (Tree.Dir.empty (Tree.Dir.repo base)) ps
-          | `Directory subdir ->
-            aux subdir ps
-          | `File f ->
-            file_on_path f >>*= fun () ->
-            aux (Tree.Dir.empty (Tree.Dir.repo base)) ps
+        let step = Store.Key.v [p] in
+        begin Store.Tree.find_tree base step >>= function
+          | None                -> aux empty ps
+          | Some (`Node subdir) -> aux (Store.Tree.of_node subdir) ps
+          | Some (`Contents f)  -> file_on_path f >>*= fun () -> aux empty ps
         end >>*= fun new_subdir ->
-        Tree.Dir.with_child base p (`Directory new_subdir) >|= fun x ->
+        Store.Tree.add_tree base step new_subdir >|= fun x ->
         Ok x
     in
     aux t.root path >>*= fun new_root ->
     t.root <- new_root;
     Lwt.return (Ok ())
 
-  let err_not_a_directory (_ : Tree.File.t * _) =
+  let err_not_a_directory (_ : Store.contents * _) =
     Lwt.return (Error `Not_a_directory)
 
-  let replace_with_dir (_ : Tree.File.t * _) =
+  let replace_with_dir (_ : Store.contents * _) =
     Lwt.return (Ok ())
 
   let update t path leaf (value, perm) =
-    let repo = Tree.Dir.repo t.root in
+    let step = Store.Key.v [leaf] in
     update_dir ~file_on_path:err_not_a_directory t path @@ fun dir ->
     let update ~old_perm =
       let perm = match perm with
         | #Ivfs_tree.perm as p -> p
-        | `Keep -> old_perm in
-      Tree.Dir.with_child dir leaf (`File (Tree.File.of_data repo value, perm))
+        | `Keep -> old_perm
+      in
+      Store.Tree.add dir step ~metadata:perm value
       >|= fun new_dir -> Ok new_dir
     in
-    Tree.Dir.lookup dir leaf >>= function
-    | `Directory _ -> Lwt.return (Error `Is_a_directory)
-    | `File (_, old_perm) -> update ~old_perm
-    | `None -> update ~old_perm:`Normal
+    Store.Tree.find_tree dir step >>= function
+    | Some (`Node _)                 -> Lwt.return (Error `Is_a_directory)
+    | Some (`Contents (_, old_perm)) -> update ~old_perm
+    | None                           -> update ~old_perm:`Normal
 
   let chmod t path leaf perm =
-    let repo = Tree.Dir.repo t.root in
+    let step = Store.Key.v [leaf] in
     update_dir ~file_on_path:err_not_a_directory t path @@ fun dir ->
-    Tree.Dir.lookup dir leaf >>= function
-    | `None -> Lwt.return (Error `No_such_item)
-    | `Directory _ when perm = `Exec -> Lwt.return (Ok dir)
-    | `Directory _ -> Lwt.return (Error `Is_a_directory)
-    | `File (f, _old_perm) ->
+    Store.Tree.find_tree dir step >>= function
+    | None                             -> Lwt.return (Error `No_such_item)
+    | Some (`Node _) when perm = `Exec -> Lwt.return (Ok dir)
+    | Some (`Node _)                   -> Lwt.return (Error `Is_a_directory)
+    | Some (`Contents (f, _old_perm))  ->
       let file =
         match perm with
-        | `Normal | `Exec as perm -> `File (f, perm)
-        | `Link target ->
-          `File (Tree.File.of_data repo (Ivfs_blob.of_string target), `Link)
+        | `Normal | `Exec as perm -> `Contents (f, perm)
+        | `Link target            -> `Contents (Ivfs_blob.of_string target, `Link)
       in
-      Tree.Dir.with_child dir leaf file >|= fun new_dir -> Ok new_dir
+      Store.Tree.add_tree dir step file >|= fun new_dir -> Ok new_dir
 
   let remove t path leaf =
+    let step = Store.Key.v [leaf] in
     update_dir ~file_on_path:err_not_a_directory t path @@ fun dir ->
-    Tree.Dir.without_child dir leaf >|= fun new_dir -> Ok new_dir
+    Store.Tree.remove dir step >|= fun new_dir -> Ok new_dir
 
   let update_force t path leaf (value, perm) =
-    let repo = Tree.Dir.repo t.root in
+    let step = Store.Key.v [leaf] in
     update_dir ~file_on_path:replace_with_dir t path (fun dir ->
-        Tree.Dir.with_child dir leaf (`File (Tree.File.of_data repo value, perm))
+        Store.Tree.add dir step ~metadata:perm value
         >|= fun new_dir -> Ok new_dir
       ) >|= doesnt_fail
 
   let remove_force t path leaf =
+    let step = Store.Key.v [leaf] in
     update_dir ~file_on_path:replace_with_dir t path (fun dir ->
-        Tree.Dir.without_child dir leaf >|= fun new_dir -> Ok new_dir
+        Store.Tree.remove dir step >|= fun new_dir -> Ok new_dir
       ) >|= doesnt_fail
 
   let rename t path ~old_name ~new_name =
+    let old_step = Store.Key.v [old_name] in
+    let new_step = Store.Key.v [new_name] in
     update_dir ~file_on_path:err_not_a_directory t path (fun dir ->
-        Tree.Dir.lookup dir old_name >>= function
-        | `None -> Lwt.return (Error `No_such_item)
-        | `File _ | `Directory _ as value ->
-          Tree.Dir.lookup dir new_name >>= function
-          | `Directory _ -> Lwt.return (Error `Is_a_directory)
-          | `None | `File _ ->
-            Tree.Dir.without_child dir old_name >>= fun dir' ->
-            Tree.Dir.with_child dir' new_name value >|= fun new_dir ->
+        Store.Tree.find_tree dir old_step >>= function
+        | None -> Lwt.return (Error `No_such_item)
+        | Some (`Contents _ | `Node _ as value) ->
+          Store.Tree.find_tree dir new_step >>= function
+          | Some (`Node _) -> Lwt.return (Error `Is_a_directory)
+          | None | Some (`Contents _) ->
+            Store.Tree.remove dir old_step >>= fun dir' ->
+            Store.Tree.add_tree dir' new_step value >|= fun new_dir ->
             Ok new_dir
       )
 end

--- a/src/datakit/ivfs_rw.ml
+++ b/src/datakit/ivfs_rw.ml
@@ -31,7 +31,7 @@ module Make (Store : Ivfs_tree.S) = struct
      [fn dir], then update all the parents back to the root. *)
   let update_dir ~file_on_path t path fn =
     Lwt_mutex.with_lock t.mutex @@ fun () ->
-    let empty = Store.Tree.empty () in
+    let empty = Store.Tree.empty in
     let rec aux base path =
       match Store.Key.decons path with
       | None -> fn base

--- a/src/datakit/ivfs_rw.mli
+++ b/src/datakit/ivfs_rw.mli
@@ -1,29 +1,27 @@
 open Result
 
-type path = Ivfs_tree.path
-type step = Ivfs_tree.step
-
-module Make (Tree: Ivfs_tree.S): sig
+module Make (Store: Ivfs_tree.S): sig
 
   type t
 
-  val of_dir: Tree.Dir.t -> t
+  val of_dir: Store.Repo.t -> Store.tree -> t
 
-  val root: t -> Tree.Dir.t
+  val root: t -> Store.tree
 
   val update:
-    t -> path -> step -> Ivfs_blob.t * [Ivfs_tree.perm | `Keep] ->
+    t -> Ivfs_tree.path -> string -> Ivfs_blob.t * [Ivfs_tree.perm | `Keep] ->
     (unit, [`Is_a_directory | `Not_a_directory]) result Lwt.t
   (** [update t dir leaf data] makes [dir/leaf] be the file [data].
       Missing directories may be created. If [dir/leaf] is a file then
       it is overwritten. Fails if [dir/leaf] is a directory, or any
       component of [dir] is not a directory. *)
 
-  val remove: t -> path -> step -> (unit, [`Not_a_directory]) result Lwt.t
+  val remove:
+    t -> Ivfs_tree.path -> string -> (unit, [`Not_a_directory]) result Lwt.t
   (** [remove t dir leaf] ensures that [dir/leaf] does not exist.
       Fails if any component of [dir] is not a directory. *)
 
-  val chmod: t -> path -> step -> Vfs.perm ->
+  val chmod: t -> Ivfs_tree.path -> string -> Vfs.perm ->
     (unit, [`Is_a_directory | `Not_a_directory | `No_such_item]) result Lwt.t
   (** [chmod t dir leaf perm] changes the type of [dir/leaf] to
       [perm]. Fails if any component of [dir] is not a directory, or
@@ -31,17 +29,18 @@ module Make (Tree: Ivfs_tree.S): sig
       changed. *)
 
   val update_force:
-    t -> path -> step -> Ivfs_blob.t * Ivfs_tree.perm -> unit Lwt.t
+    t -> Ivfs_tree.path -> string -> Ivfs_blob.t * Ivfs_tree.perm ->
+    unit Lwt.t
   (** [update_force t path leaf value] ensures that [path/leaf] is a
       file containing [value]. Any existing files and directories that
       are in the way are destroyed. *)
 
-  val remove_force: t -> path -> step -> unit Lwt.t
+  val remove_force: t -> Ivfs_tree.path -> string -> unit Lwt.t
   (** [remove_force t path leaf] ensures that [path/leaf] does not
       exist. This will delete the entire subtree if [path/leaf] is a
       directory. It does nothing if [path/leaf] does not exist. *)
 
-  val rename: t -> path -> old_name:step -> new_name:step ->
+  val rename: t -> Ivfs_tree.path -> old_name:string -> new_name:string ->
     (unit, [`Is_a_directory | `Not_a_directory | `No_such_item]) result Lwt.t
   (** [rename t path ~old_name ~new_name] ensures that [path/new_name]
       points to whatever [path/old_name] previously did, and that

--- a/src/datakit/ivfs_tree.ml
+++ b/src/datakit/ivfs_tree.ml
@@ -1,25 +1,21 @@
 (* FIXME: upstream that module *)
 
 open Astring
-open Lwt.Infix
 
 type perm = [ `Normal | `Exec | `Link ]
 
 module Path: Irmin.Path.S with type step = string = struct
 
   type step = string
+  let step_t = Irmin.Type.string
+  let pp_step ppf x = Fmt.string ppf x
+  let step_of_string = function
+    | "" -> Error (`Msg "Empty step!")
+    | s  -> Ok s
 
-  module Step = struct
-    include Tc.String
-    let to_hum s = s
-    let of_hum = function
-      | "" -> invalid_arg "Empty step!"
-      | s  -> s
-  end
 
-  include Tc.List(Step)
-  let to_json t = to_json (List.rev t)
-  let of_json j = List.rev (of_json j)
+  type t = string list
+  let t = Irmin.Type.(list string)
 
   let empty = []
   let is_empty l = (l = [])
@@ -36,322 +32,42 @@ module Path: Irmin.Path.S with type step = string = struct
     | h::t -> Some (h, List.rev t)
 
   let map l f = List.map f l
-  let create x = x
-  let to_hum t = String.concat ~sep:"/" (List.rev t)
+  let v x = List.rev x
+  let pp ppf t = Fmt.(list ~sep:(unit "/") string) ppf (List.rev t)
 
   (* XXX: slow *)
-  let of_hum s =
+  let of_string s =
     List.filter ((<>)"") (String.cuts s ~sep:"/")
-    |> List.map Step.of_hum
     |> List.rev
+    |> fun x -> Ok x
 
 end
 
+type step = Path.step
 type path = Path.t
-type step = Path.Step.t
 
-module PathMap = struct
-  include Map.Make(Path)
-  let of_list l = List.fold_left (fun m (k, v) -> add k v m) empty l
-end
-module PathSet = Set.Make(Path)
-
-module StepMap = Asetmap.Map.Make(Path.Step)
-
-module type STORE = Irmin.S
+module type S = Irmin.S
   with type key = path
-   and type value = string
-   and type branch_id = string
-   and module Key = Path
-   and type Private.Node.Val.step = string
-   and type Private.Node.Val.Metadata.t = perm
+   and type contents = Ivfs_blob.t
+   and type branch = string
+   and type step = step
+   and type metadata = perm
 
-module type S = sig
-  type repo
-  type store
-  module File: sig
-    type t
-    type hash
-    val of_data: repo -> Ivfs_blob.t -> t
-    val hash: t -> hash Lwt.t
-    val content: t -> Ivfs_blob.t Lwt.t
-    val size: t -> int64 Lwt.t
-    val pp: t Fmt.t
-    val pp_hash: Format.formatter -> hash -> unit
-    val compare_hash: hash -> hash -> int
-  end
-  module Dir: sig
-    type t
-    type hash
-    val empty: repo -> t
-    val ty: t -> step -> [`File | `Directory | `None] Lwt.t
-    val lookup:
-      t -> step -> [`File of File.t * perm | `Directory of t | `None ] Lwt.t
-    val lookup_path:
-      t -> path -> [`File of File.t * perm | `Directory of t | `None ] Lwt.t
-    val get: t -> path -> t option Lwt.t
-    val map: t -> [`File of File.t * perm | `Directory of t] StepMap.t Lwt.t
-    val ls: t -> ([`File | `Directory] * step) list Lwt.t
-    val iter: t -> (path -> File.t * perm  -> unit Lwt.t) -> unit Lwt.t
-    val of_hash: repo -> hash -> t
-    val hash: t -> hash Lwt.t
-    val repo: t -> repo
-    val with_child:
-      t -> step -> [`File of File.t * perm | `Directory of t] -> t Lwt.t
-    val without_child: t -> step -> t Lwt.t
-    val diff: t -> t -> (path * (File.t * perm) Irmin.diff) list Lwt.t
-  end
-  val snapshot: store -> Dir.t Lwt.t
+module Blobs = struct
+  include Ivfs_blob
+  let merge = Irmin.Merge.(option @@ default t)
+  let of_string x = Ok (of_string x)
 end
 
-module Make (Store: STORE) = struct
-  type store = Store.t
-  type repo = Store.Repo.t
+module type MAKER =
+  functor (C: Irmin.Contents.S) ->
+  functor (P: Irmin.Path.S) ->
+  functor (B: Irmin.Branch.S) ->
+    Irmin.S with type key = P.t
+             and type step = P.step
+             and module Key = P
+             and type contents = C.t
+             and type branch = B.t
+             and type metadata = perm
 
-  module File = struct
-
-    type hash = Store.Private.Contents.Key.t
-
-    (* For now, a value is either in memory or on disk. In future, we
-       may want to support both at once for caching. *)
-    type value =
-      | Blob of Ivfs_blob.t
-      | Hash of Store.Private.Contents.key
-
-    type t = {
-      repo: Store.Repo.t;
-      mutable value: value;
-    }
-
-    let of_data repo value =
-      { repo; value = Blob value }
-
-    let of_hash repo hash =
-      { repo; value = Hash hash }
-
-    let hash f =
-      match f.value with
-      | Hash h -> Lwt.return h
-      | Blob b ->
-        let contents_t = Store.Private.Repo.contents_t f.repo in
-        let data = Ivfs_blob.to_string b in
-        Store.Private.Contents.add contents_t data >|= fun hash ->
-        f.value <- Hash hash;
-        hash
-
-    let compare_hash a b =
-      Store.Private.Contents.Key.compare a b
-
-    let content f =
-      match f.value with
-      | Blob b -> Lwt.return b
-      | Hash h ->
-        let contents_t = Store.Private.Repo.contents_t f.repo in
-        Store.Private.Contents.read_exn contents_t h >|= fun data ->
-        Ivfs_blob.of_string data
-
-    let size f =
-      (* TODO: provide a more efficient API in Irmin to get sizes *)
-      content f >|= Ivfs_blob.len
-
-    let pp_hash fmt hash =
-      Fmt.string fmt (Store.Private.Contents.Key.to_hum hash)
-
-    let pp ppf t = match t.value with
-      | Blob b -> Fmt.pf ppf "blob:%a" Ivfs_blob.pp b
-      | Hash h -> Fmt.pf ppf "hash:%a" pp_hash h
-
-  end
-
-  module Dir = struct
-    type hash = Store.Private.Node.Key.t
-    type map = [`File of File.t * perm | `Directory of t] StepMap.t
-
-    and value =
-      | Hash of hash * map Lwt.t Lazy.t
-      | Map_only of map
-
-    and t = {
-      repo: Store.Repo.t;
-      mutable value: value;
-    }
-
-    let empty repo = {repo; value = Map_only StepMap.empty}
-
-    let map dir =
-      match dir.value with
-      | Map_only m -> Lwt.return m
-      | Hash (_, lazy m) -> m
-
-    let rec of_hash repo hash =
-      let map = lazy (
-        let node_t = Store.Private.Repo.node_t repo in
-        Store.Private.Node.read_exn node_t hash >|= fun node ->
-        Store.Private.Node.Val.alist node
-        |> List.fold_left (fun acc (name, item) ->
-            acc |> StepMap.add (Path.Step.of_hum name) (
-              match item with
-              | `Contents (h, perm) -> `File (File.of_hash repo h, perm)
-              | `Node h -> `Directory (of_hash repo h)
-            )
-          ) StepMap.empty
-      ) in
-      { repo; value = Hash (hash, map) }
-
-    let ty dir step =
-      map dir >|= fun m ->
-      match StepMap.find step m with
-      | None -> `None
-      | Some (`File _) -> `File
-      | Some (`Directory _) -> `Directory
-
-    let lookup dir step =
-      map dir >|= fun m ->
-      match StepMap.find step m with
-      | Some (`Directory _ | `File _ as r) -> r
-      | None -> `None
-
-    let rec lookup_path dir path = match Path.decons path with
-      | None         -> Lwt.return (`Directory dir)
-      | Some (p, ps) ->
-        lookup dir p >>= function
-        | `Directory d -> lookup_path d ps
-        | `File _ as x when Path.is_empty ps -> Lwt.return x
-        | `None | `File _ -> Lwt.return `None
-
-    let get dir path =
-      lookup_path dir path >|= function
-      | `Directory d -> Some d
-      | `None | `File _ -> None
-
-    (* TODO: just return the full map, now that we load it anyway *)
-    let ls dir =
-      map dir >|= fun m ->
-      StepMap.bindings m
-      |> List.map (fun (name, value) ->
-          match value with
-          | `File _ -> `File, name
-          | `Directory _ -> `Directory, name
-        )
-
-    let rec hash t =
-      match t.value with
-      | Hash (h, _) -> Lwt.return h
-      | Map_only m ->
-        StepMap.bindings m
-        |> Lwt_list.fold_left_s (fun acc item ->
-            match item with
-            | name, `File (f, perm) ->
-              File.hash f >|= fun h ->
-              (Path.Step.to_hum name, `Contents (h, perm)) :: acc
-            | name, `Directory d ->
-              map d >>= fun map ->
-              if StepMap.is_empty map then (
-                (* Ignore empty directories *)
-                Lwt.return acc
-              ) else (
-                hash d >|= fun h ->
-                (Path.Step.to_hum name, `Node h) :: acc
-              )
-          ) []
-        >|= Store.Private.Node.Val.create
-        >>= Store.Private.Node.add (Store.Private.Repo.node_t t.repo)
-
-    let repo a = a.repo
-
-    let with_child t step child =
-      map t >|= fun m ->
-      let m = StepMap.add step child m in
-      { repo = t.repo; value = Map_only m }
-
-    let without_child t step =
-      map t >|= fun m ->
-      let m = StepMap.remove step m in
-      { repo = t.repo; value = Map_only m }
-
-    module KV = struct
-        type t = Path.t * (File.hash * perm)
-        let compare (p1, (h1, perm1)) (p2, (h2, perm2)) =
-          match Path.compare p1 p2 with
-          | 0 ->
-            begin match File.compare_hash h1 h2 with
-              | 0 -> Pervasives.compare perm1 perm2
-              | i -> i
-            end
-          | i -> i
-    end
-    module KVSet = Set.Make(KV)
-
-    let iter t fn =
-      let rec aux = function
-        | []            -> Lwt.return_unit
-        | (t, path)::tl ->
-          map t >>= fun childs ->
-          let childs = StepMap.bindings childs in
-          Lwt_list.fold_left_s (fun acc (k, v) ->
-              match v with
-              | `Directory  t -> Lwt.return ((t, Path.rcons path k) :: acc)
-              | `File f       -> fn (Path.rcons path k) f >|= fun () -> acc
-            ) [] childs
-          >>= fun dirs ->
-          let todo = dirs @ tl in
-          aux todo
-      in
-      aux [t, Path.empty]
-
-    let diff x y =
-      let set t =
-        let acc = ref KVSet.empty in
-        iter t (fun k (v, p) ->
-            File.hash v >>= fun v ->
-            acc := KVSet.add (k, (v, p)) !acc;
-            Lwt.return_unit
-          ) >>= fun () ->
-        Lwt.return !acc
-      in
-      let find path map =
-        let f, p = PathMap.find path map in
-        File.of_hash x.repo f, p
-      in
-      (* FIXME very dumb and slow *)
-      set x >>= fun sx ->
-      set y >>= fun sy ->
-      let added     = KVSet.diff sy sx in
-      let removed   = KVSet.diff sx sy in
-      let added_l   = KVSet.elements added in
-      let removed_l = KVSet.elements removed in
-      let added_m   = PathMap.of_list added_l in
-      let removed_m = PathMap.of_list removed_l in
-      let added_p   = PathSet.of_list (List.map fst added_l) in
-      let removed_p = PathSet.of_list (List.map fst removed_l) in
-      let updated_p = PathSet.inter added_p removed_p in
-      let added_p   = PathSet.diff added_p updated_p in
-      let removed_p = PathSet.diff removed_p updated_p in
-      let added =
-        PathSet.fold (fun path acc ->
-            (path, `Added (find path added_m)) :: acc
-          ) added_p []
-      in
-      let removed =
-        PathSet.fold (fun path acc ->
-            (path, `Removed (find path removed_m)) :: acc
-          ) removed_p []
-      in
-      let updated =
-        PathSet.fold (fun path acc ->
-            let x = find path removed_m in
-            let y = find path added_m in
-            (path, `Updated (x, y)) :: acc
-          ) updated_p []
-      in
-      Lwt.return (added @ updated @ removed)
-
-  end
-
-  let snapshot store =
-    let repo = Store.repo store in
-    Store.Private.read_node store Path.empty >|= function
-    | None -> Dir.empty repo
-    | Some hash -> Dir.of_hash repo hash
-
-end
+module Make (M: MAKER) = M(Blobs)(Path)(Irmin.Branch.String)

--- a/src/datakit/ivfs_tree.mli
+++ b/src/datakit/ivfs_tree.mli
@@ -7,126 +7,27 @@
 
 module Path: Irmin.Path.S with type step = string
 
-type step = string
+type step = Path.step
 type path = Path.t
 type perm = [ `Normal | `Exec | `Link ]
 
-module type STORE = Irmin.S
+module type S = Irmin.S
   with type key = path
-   and type value = string
-   and type branch_id = string
-   and module Key = Path
-   and type Private.Node.Val.step = string
-   and type Private.Node.Val.Metadata.t = perm
+   and type contents = Ivfs_blob.t
+   and type branch = string
+   and type step = step
+   and type metadata = perm
 
-module type S = sig
+(* to avoid a direct dependency with Irmin_git *)
+module type MAKER =
+  functor (C: Irmin.Contents.S) ->
+  functor (P: Irmin.Path.S) ->
+  functor (B: Irmin.Branch.S) ->
+    Irmin.S with type key = P.t
+             and type step = P.step
+             and module Key = P
+             and type contents = C.t
+             and type branch = B.t
+             and type metadata = perm
 
-  type store
-  (** The type for Irmin stores. *)
-
-  type repo
-  (** The type for Irmin repositories. *)
-
-  module File: sig
-
-    type t
-    (** The type for file contents. *)
-
-    type hash
-    (** The type for file IDs (hashes). *)
-
-    val of_data: repo -> Ivfs_blob.t -> t
-    (** [of_data repo data] is a file containing [data], which may
-        later be stored in [repo]. *)
-
-    val hash: t -> hash Lwt.t
-    (** [hash f] is the hash of the contents of [f]. If [f] is not yet
-        in [repo], calling this will cause it to be written. *)
-
-    val content: t -> Ivfs_blob.t Lwt.t
-    (** [content t] is [t]'s contents. *)
-
-    val size: t -> int64 Lwt.t
-    (** [size t] is [t]'s size. *)
-
-    val pp: t Fmt.t
-    (** [pp] is a pretty-printer for files. *)
-
-    val pp_hash: Format.formatter -> hash -> unit
-    (** [pp_hash] is the pretty-printer for file's hashes. *)
-
-    val compare_hash: hash -> hash -> int
-    (** [compare_hash] is the comparison function for file hashes. *)
-
-  end
-
-  module Dir: sig
-
-    type t
-    (** An immutable directory node. Note: normally we treat an empty
-        directory as an error, but we do allow it for the root. *)
-
-    type hash
-    (** The type for directory IDs (hashes). *)
-
-    val empty: repo -> t
-
-    val ty: t -> step -> [`File | `Directory | `None] Lwt.t
-    (** Check the type of a path. *)
-
-    val lookup:
-      t -> step -> [`File of File.t * perm | `Directory of t | `None ] Lwt.t
-    (** Look up an immediate child by name. *)
-
-    val lookup_path:
-      t -> path -> [`File of File.t * perm | `Directory of t | `None ] Lwt.t
-    (** Look up an item by path. *)
-
-    val get: t -> path -> t option Lwt.t
-    (** Look up a sub-directory node. *)
-
-    val map: t -> [`File of File.t * perm | `Directory of t]
-        Map.Make(Path.Step).t Lwt.t
-    (** The contents of the directory. *)
-
-    val ls: t -> ([`File | `Directory] * step) list Lwt.t
-    (** List the contents of a directory with the type of each item. *)
-
-    val iter: t -> (path -> File.t * perm -> unit Lwt.t) -> unit Lwt.t
-    (** [iter t f] applies [f] over all sub-files. *)
-
-    val of_hash: repo -> hash -> t
-    (** [of_hash repo h] is the directory whose hash is [h] in [repo]. *)
-
-    val hash: t -> hash Lwt.t
-    (** [hash dir] is [dir]'s hash. This writes [dir] to the
-        repository if it's not yet stored. *)
-
-    val repo: t -> repo
-    (** [repo dir] is the repository in which [dir] lives. *)
-
-    val with_child:
-      t -> step -> [`File of File.t * perm | `Directory of t] -> t Lwt.t
-    (** [with_child dir name child] is a copy of [dir] except that
-        [name] links to [child]. *)
-
-    val without_child: t -> step -> t Lwt.t
-    (** [without_child dir name] is a copy of [dir] except that it has
-        no child called [name]. *)
-
-    val diff: t -> t -> (path * (File.t * perm) Irmin.diff) list Lwt.t
-    (** [diff x y] is the list of files which are different between
-        [x] and [y]. *)
-
-  end
-
-  val snapshot: store -> Dir.t Lwt.t
-  (** Convert a branch, which may update while we read it, to a fixed
-      directory by reading its current root. *)
-
-end
-
-module Make (Store: STORE):
-  S with type store = Store.t
-     and type repo = Store.Repo.t
-     and type Dir.hash = Store.Private.Node.Key.t
+module Make (M: MAKER): S

--- a/src/datakit/main.ml
+++ b/src/datakit/main.ml
@@ -43,7 +43,7 @@ let max_chunk_size = Int32.of_int (100 * 1024)
 
 let info msg =
   let date = Int64.of_float (Unix.gettimeofday ()) in
-  Irmin.Info.v ~date ~author:"datakit <datakit@docker.com>" msg
+  Irmin.Info.v ~date ~author:"datakit <datakit@mobyproject.org>" msg
 
 module Git_fs_store = struct
   open Datakit_io

--- a/src/datakit_io.ml
+++ b/src/datakit_io.ml
@@ -136,11 +136,7 @@ module FS = struct
       ) in
     Lwt_pool.use mkdir_pool (fun () -> aux dirname)
 
-  let file_exists f =
-    Lwt.catch (fun () -> Lwt_unix.file_exists f) (function
-        (* See https://github.com/ocsigen/lwt/issues/316 *)
-        | Unix.Unix_error (Unix.ENOTDIR, _, _) -> Lwt.return_false
-        | e -> Lwt.fail e)
+  let file_exists f = Lwt_unix.file_exists f
 
   module Lock = struct
 

--- a/src/datakit_io.mli
+++ b/src/datakit_io.mli
@@ -1,4 +1,3 @@
-module Sync: Git.Sync.IO
+module IO: Irmin_git.IO
 module Zlib: Git.Inflate.S
-module Lock: Irmin_git.LOCK
 module FS: Git.FS.IO

--- a/src/datakit_log.ml
+++ b/src/datakit_log.ml
@@ -21,7 +21,7 @@ type t =
   | Eventlog
   | ASL
 
-let conv = Arg.enum [
+let mk = Arg.enum [
     "quiet"    , Quiet;
     "timestamp", Timestamp;
     "eventlog" , Eventlog;
@@ -80,7 +80,7 @@ let log_destination =
   let doc =
     Arg.info ~docs ~doc:"Destination for the logs" [ "log-destination" ]
   in
-  Arg.(value & opt conv Quiet & doc)
+  Arg.(value & opt mk Quiet & doc)
 
 let log_clock =
   let doc = Arg.info ~docs ~doc:"Kind of clock" ["log-clock"] in

--- a/tests/test.ml
+++ b/tests/test.ml
@@ -573,10 +573,9 @@ let test_rw () =
   let v x = Ivfs_blob.of_string x, `Normal in
   let err = (module RW_err : Alcotest.TESTABLE with type t = RW_err.t) in
   let err1 = (module RW_err1 : Alcotest.TESTABLE with type t = RW_err1.t) in
-  let empty = Store.Tree.empty () in
   Lwt_main.run begin
     Store.Repo.v config >>= fun repo ->
-    let rw = RW.of_dir repo empty in
+    let rw = RW.of_dir repo Store.Tree.empty in
 
     RW.update rw (p []) "foo" (v "a")
     >|= Alcotest.(check (result unit err)) "Write /a" (Ok ()) >>= fun () ->

--- a/tests/test.ml
+++ b/tests/test.ml
@@ -2,7 +2,8 @@ open Lwt.Infix
 open Test_utils
 open Result
 
-let p l = Ivfs_tree.Path.of_hum (String.concat "/" l)
+let p l = Ivfs_tree.Path.v l
+let v b = Ivfs_blob.of_string b
 
 let root_entries = ["branch"; "debug"; "snapshots"; "trees"; "remotes"]
 
@@ -35,11 +36,11 @@ let test_transaction repo conn =
   let length = Int64.to_int info.Protocol_9p.Types.Stat.length in
   Alcotest.(check int) "File size" 15 length;
 
-  Store.master Irmin.Task.none repo >>= fun master ->
-  Store.head_exn (master ()) >>=
-  Store.Repo.task_of_commit_id repo >>= fun task ->
-  let msg = Irmin.Task.messages task in
-  Alcotest.(check (list string)) "Message" ["My commit"] msg;
+  Store.master repo >>= fun master ->
+  Store.Head.get master >>= fun commit ->
+  let info = Store.Commit.info commit in
+  let msg = Irmin.Info.message info in
+  Alcotest.(check string) "Message" "My commit" msg;
 
   Lwt.return_unit
 
@@ -336,9 +337,10 @@ let test_qids _repo conn =
     ) >>*=
   Lwt.return
 
+let info = Irmin.Info.none
+
 let test_watch repo conn =
-  Store.master (fun () -> Irmin.Task.empty) repo >>= fun master ->
-  let master = master () in
+  Store.master repo >>= fun master ->
   Client.mkdir conn ["branch"] "master" rwxr_xr_x >>*= fun () ->
   with_stream conn ["branch"; "master"; "watch"; "tree.live"] @@ fun top ->
   read_line_exn top >>= fun top_init ->
@@ -349,7 +351,10 @@ let test_watch repo conn =
   @@ fun doc ->
   read_line_exn doc >>= fun doc_init ->
   Alcotest.(check string) "Doc tree hash initially empty" "" doc_init;
-  Store.update master (p ["src"; "Makefile"]) "all: build" >>= fun () ->
+  Store.set master ~info (p ["src"; "Makefile"]) (v "all: build") >>= fun () ->
+  Store.get master (p ["src"; "Makefile"]) >>= fun makefile_init ->
+  Alcotest.(check string)
+    "Makefile contents" "all: build" (Ivfs_blob.to_string makefile_init);
   with_stream conn
     ["branch"; "master"; "watch"; "src.node"; "Makefile.node"; "tree.live"]
   @@ fun makefile ->
@@ -358,7 +363,7 @@ let test_watch repo conn =
     "F-d81e367f87ee314bcd3e449b1c6641efda5bc269" makefile_init;
   (* Modify file under doc *)
   let next_make = makefile () in
-  Store.update master (p ["doc"; "README"]) "Instructions" >>= fun () ->
+  Store.set ~info master (p ["doc"; "README"]) (v "Instructions") >>= fun () ->
   read_line_exn doc >>= fun doc_new ->
   Alcotest.(check string) "Doc update"
     "D-a3e8adf6d194bfbdec2ca73aebe0990edee2ddbf" doc_new;
@@ -372,9 +377,8 @@ let test_watch repo conn =
   Lwt.return_unit
 
 let test_rename_branch repo conn =
-  Store.of_branch_id Irmin.Task.none "old" repo >>= fun old ->
-  let old = old () in
-  Store.update old (p ["key"]) "value" >>= fun () ->
+  Store.of_branch repo "old" >>= fun old ->
+  Store.set ~info old (p ["key"]) (v "value") >>= fun () ->
   Client.mkdir conn ["branch"] "old" rwxr_xr_x >>*= fun () ->
   Client.with_fid conn (fun newfid ->
       Client.walk_from_root conn newfid ["branch"; "old"] >>*= fun _ ->
@@ -385,13 +389,12 @@ let test_rename_branch repo conn =
   check_dir conn ["branch"] "New branches" ["new"] >>= fun () ->
   Client.stat conn ["branch"; "new"] >>*= fun info ->
   Alcotest.(check string) "Inode name" "new" info.Protocol_9p.Types.Stat.name;
-  let refs = Store.Private.Repo.ref_t repo in
-  Store.Private.Ref.mem refs "old" >>= fun old_exists ->
-  Store.Private.Ref.mem refs "new" >>= fun new_exists ->
+  Store.Branch.mem repo "old" >>= fun old_exists ->
+  Store.Branch.mem repo "new" >>= fun new_exists ->
   Alcotest.(check bool) "Old gone" false old_exists;
   Alcotest.(check bool) "New appeared" true new_exists;
   Client.remove conn ["branch"; "new"] >>*= fun () ->
-  Store.Private.Ref.mem refs "new" >>= fun new_exists ->
+  Store.Branch.mem repo "new" >>= fun new_exists ->
   Alcotest.(check bool) "New gone" false new_exists;
   Lwt.return_unit
 
@@ -570,9 +573,10 @@ let test_rw () =
   let v x = Ivfs_blob.of_string x, `Normal in
   let err = (module RW_err : Alcotest.TESTABLE with type t = RW_err.t) in
   let err1 = (module RW_err1 : Alcotest.TESTABLE with type t = RW_err1.t) in
+  let empty = Store.Tree.empty () in
   Lwt_main.run begin
-    Store.Repo.create config >>= fun repo ->
-    let rw = RW.of_dir (Tree.Dir.empty repo) in
+    Store.Repo.v config >>= fun repo ->
+    let rw = RW.of_dir repo empty in
 
     RW.update rw (p []) "foo" (v "a")
     >|= Alcotest.(check (result unit err)) "Write /a" (Ok ()) >>= fun () ->
@@ -605,8 +609,8 @@ let test_rw () =
 
     let root = RW.root rw in
 
-    Tree.Dir.ls root
-    >|= List.map snd
+    Store.Tree.list root Store.Key.empty
+    >|= List.map fst
     >|= Alcotest.(check (slist string String.compare)) "ls /" ["foo"; "sub"]
     >>= fun () ->
 

--- a/tests/test_client.ml
+++ b/tests/test_client.ml
@@ -597,7 +597,8 @@ let test_truncate dk =
 
 (* FIXME: automaticall run ./scripts/git-dumb-server *)
 let test_remotes dk =
-  DK.fetch dk ~url:"git://localhost/" ~branch:"origin" >>*= fun fetch_head ->
+  DK.fetch dk ~url:"git://localhost/#master" ~branch:"origin"
+  >>*= fun fetch_head ->
   DK.Tree.read_dir (DK.Commit.tree fetch_head) (p "") >>*= fun items ->
   Alcotest.(check (list string)) "Remotes entries" ["foo"; "x"] items;
   Lwt.return_unit


### PR DESCRIPTION
This patch make Irmin 1.1 works with DataKit. As Irmin 1.1 only
works with cmdliner >= 1.0 and MirageOS >= 3.0, also update
these dependencies.

The main change is the removal of the body Ivfs_tree to use the new
Irmin API. The new Irmin Tree API is pretty similar (on purpose) but
it seems that we are loosing caching of file hashes. I plan to re-add
that in a later commit, after checking it is really needed.

Ideally datakit-client will also move to something closer to the Irmin API
but it is not a blocker for API compatibility.

Signed-off-by: Thomas Gazagnaire <thomas@gazagnaire.org>