### PR TITLE
ci: make required GitHub scopes configurable

### DIFF
--- a/ci/self-ci/selfCI.ml
+++ b/ci/self-ci/selfCI.ml
@@ -102,6 +102,7 @@ let make_config ?state_repo ~listen_addr ~remote () =
     Web.config
       ~name:"datakit-ci"
       ?state_repo
+      ~github_scopes_needed:[`Read_org]
       ~can_read:ACL.everyone
       ~can_build
       ~listen_addr

--- a/ci/src/cI_main.ml
+++ b/ci/src/cI_main.ml
@@ -50,7 +50,9 @@ let start_lwt ~pr_store ~web_ui ~secrets_dir ~canaries ~config ~session_backend 
   let projects = Repo.Map.map (fun p -> p.CI_config.tests) projects in
   CI_secrets.create ~key_bits secrets_dir >>= fun secrets ->
   CI_secrets.github_auth secrets >>= fun github ->
-  CI_web_utils.Auth.create ~github ~web_ui (CI_secrets.passwords_path secrets) >>= fun auth ->
+  let github_scopes_needed = web_config.CI_web_templates.github_scopes_needed in
+  let passwd_path = CI_secrets.passwords_path secrets in
+  CI_web_utils.Auth.create ~github ~github_scopes_needed ~web_ui passwd_path >>= fun auth ->
   let (proto, addr) = pr_store in
   let connect_dk () = connect proto addr >|= DK.connect in
   let canaries =

--- a/ci/src/cI_web_templates.mli
+++ b/ci/src/cI_web_templates.mli
@@ -7,6 +7,7 @@ type t = private {
   state_repo : Uri.t option;
   metrics_token : [`SHA256 of Cstruct.t] option;
   listen_addr: [`HTTP of int | `HTTPS of int];
+  github_scopes_needed : Github_t.scope list;
   can_read : CI_ACL.t;
   can_build : CI_ACL.t;
 }
@@ -16,6 +17,7 @@ val config:
   ?state_repo:Uri.t ->
   ?metrics_token:[`SHA256 of string] ->
   ?listen_addr:[`HTTP of int | `HTTPS of int] ->
+  ?github_scopes_needed:Github_t.scope list ->
   can_read:CI_ACL.t ->
   can_build:CI_ACL.t ->
   unit -> t

--- a/ci/src/cI_web_utils.mli
+++ b/ci/src/cI_web_utils.mli
@@ -16,10 +16,15 @@ end
 module Auth : sig
   type t
 
-  val create : github:CI_secrets.github_auth CI_secrets.secret -> web_ui:Uri.t -> string -> t Lwt.t
-  (** [create ~github ~web_ui passwd_file] is a user authenticator with configuration at [passwd_file].
-      If [passwd_file] does not exist, a one-time configuration URL under [web_ui] is printed
-      to the logs. [passwd_file] must be an absolute path. *)
+  val create :
+    github:CI_secrets.github_auth CI_secrets.secret ->
+    github_scopes_needed:Github_t.scope list ->
+    web_ui:Uri.t -> string -> t Lwt.t
+  (** [create ~github ~github_scopes_needed ~web_ui passwd_file] is a user
+      authenticator with configuration at [passwd_file].
+      If [passwd_file] does not exist, a one-time configuration URL under
+      [web_ui] is printed to the logs.
+      [passwd_file] must be an absolute path. *)
 
   val lookup : t -> user:string -> password:string -> User.t option
   (** [lookup t (username, password)] returns the user with name [username] if the user exists and

--- a/ci/src/datakit_ci.mli
+++ b/ci/src/datakit_ci.mli
@@ -339,12 +339,18 @@ module Web: sig
       (`SHA256 expected)] given then doing an HTTP GET on [/metrics]
       with an Authorization header containing "Bearer TTT" will return
       Prometheus-format metrics if sha256(TTT) = expected. There is no
-      rate limiting, so pick a long [token]. *)
+      rate limiting, so pick a long [token].
+      [github_scopes_needed] should be [`Read_org; `Public_repo] to check whether
+      users can access a public repository, or [`Read_org, `Repo] to check
+      access to private repos. Unfortunately, the GitHub API requires us to
+      ask for far more permissions than we need.
+  *)
   val config:
     ?name:string ->
     ?state_repo:Uri.t ->
     ?metrics_token:[`SHA256 of string] ->
     ?listen_addr:[`HTTP of int | `HTTPS of int] ->
+    ?github_scopes_needed:Github_t.scope list ->
     can_read:ACL.t ->
     can_build:ACL.t ->
     unit -> config

--- a/ci/tests/test_ci.ml
+++ b/ci/tests/test_ci.ml
@@ -471,7 +471,7 @@ let with_test_auth fn =
       output_string ch "((admin((prf SHA1)(salt\"\\172~\\212>|'\\154\\202\\224\\128?\\158\\160\\245\\243j\")(hashed_password\"_\\231gB\\136\\221\\159!\\164%\\024\\\"0H\\\"\\230\\172\\142\\166\\138\")(count 5000)(dk_len 20))))";
       close_out ch;
       let github = CI_secrets.const None in
-      CI_web_utils.Auth.create ~github ~web_ui:(Uri.of_string "https://localhost") path >>= fn
+      CI_web_utils.Auth.create ~github ~github_scopes_needed:[] ~web_ui:(Uri.of_string "https://localhost") path >>= fn
     )
 
 let test_auth () =


### PR DESCRIPTION
Before, we always asked for access to all public and private repos, in case we needed to check if the user had access to a private repo. Now, a CI can request only access to public repos if that's all it needs.

Workaround until https://github.com/mirage/ocaml-github/issues/185 is implemented.

/cc @avsm