### PR TITLE
self-ci: update to use github bridge 0.10

### DIFF
--- a/bridge/github/README.md
+++ b/bridge/github/README.md
@@ -45,7 +45,6 @@ To run it:
       -v /path/to/jar/datakit:/run/secrets/datakit-github-cookie \
       datakit-github \
       --datakit=tcp:x.x.x.x:6640 \
-      --no-listen \
       --verbose \
       --webhook=http://my-ip
 

--- a/ci/self-ci/datakit-ci.yml
+++ b/ci/self-ci/datakit-ci.yml
@@ -2,7 +2,7 @@ version: '3.1'
 
 services:
   bridge:
-    command: '--listen-prometheus=9090 --datakit tcp://datakit:5640 --no-listen -v -c "*:r,status[ci/datakit]:x,webhook:rw" --webhook http://hooks.datakit.ci:81 --log-destination timestamp'
+    command: '--listen-prometheus=9090 --datakit tcp://datakit:5640 -v -c "*:r,status[ci/datakit]:x,webhook:rw" --webhook http://hooks.datakit.ci:81 --log-destination timestamp'
     image: 'datakit/github-bridge'
     ports:
       - '81:81'


### PR DESCRIPTION
--no-listen is now the default argument as there is no listening option
anymore since #535

Signed-off-by: Thomas Gazagnaire <thomas@gazagnaire.org>