### PR TITLE
9p client: make DK.commit fail if the commit does not exist

### DIFF
--- a/ci/tests/test_ci.ml
+++ b/ci/tests/test_ci.ml
@@ -604,6 +604,13 @@ module DK_Commit = struct
   let equal a b = (id a = id b)
 end
 
+let empty_commit () =
+  let open Test_utils in
+  Store.Repo.v config >>= fun repo ->
+  Store.Commit.v repo ~info:Irmin.Info.empty ~parents:[] Store.Tree.empty
+  >|= fun c ->
+  Fmt.to_to_string Store.Commit.pp c
+
 let test_history conn =
   let module DK = CI_utils.DK in
   let ( >>*= ) x f =
@@ -637,7 +644,8 @@ let test_history conn =
       "three", (Error (`Pending "Testing"), CI_output.Live live);
     ]
   in
-  DK.commit dk "abc" >>*= fun metadata_commit ->
+  empty_commit () >>= fun empty ->
+  DK.commit dk empty >>*= fun metadata_commit ->
   CI_history.record master_h dk ~source_commit metadata_commit s1 >>= fun () ->
   (* Check s1 *)
   CI_history.head master_h |> Test_utils.or_fail "No head state!" |> CI_history.State.jobs |> Alcotest.check jobs_t "Initial commit" s1;

--- a/circle.yml
+++ b/circle.yml
@@ -15,6 +15,7 @@ dependencies:
   override:
   - brew update && brew upgrade
   - brew install wget ocaml opam dylibbundler
+  - if [ -e ~/.opam ] && ! [ -e ~/.opam/repo/config ]; then rm -rf ~/.opam; fi
   - opam init --comp system -n https://github.com/ocaml/opam-repository.git
   - opam switch system
   - opam pin add hvsock --dev -n

--- a/circle.yml
+++ b/circle.yml
@@ -19,9 +19,10 @@ dependencies:
   - opam init --comp system -n https://github.com/ocaml/opam-repository.git
   - opam switch system
   - opam pin add hvsock --dev -n
-  - opam pin add irmin.1.2.0 --dev -n
-  - opam pin add irmin-mem.1.2.0 -n https://github.com/mirage/irmin.git
-  - opam pin add irmin-git.1.2.0 --dev -n
+  - opam pin add git.dev --dev
+  - opam pin add irmin.dev --dev -n
+  - opam pin add irmin-mem.dev -n https://github.com/mirage/irmin.git
+  - opam pin add irmin-git.dev --dev -n
   - opam pin add datakit-server.dev . -n
   - opam pin add datakit-server-9p.dev . -n
   - opam pin add datakit.dev . -n

--- a/tests/datakit-9p/test.ml
+++ b/tests/datakit-9p/test.ml
@@ -11,7 +11,8 @@ module Client = Protocol_9p.Client.Make(Log9p)(Test_flow)
 let p l = Ivfs_tree.Path.v l
 let v b = Ivfs_blob.of_string b
 
-let root_entries = ["branch"; "debug"; "snapshots"; "trees"; "remotes"]
+let root_entries =
+  ["branch"; "debug"; "snapshots"; "trees"; "commits"; "remotes"]
 
 let run fn =
   Lwt_main.run begin


### PR DESCRIPTION
Previously, this will fail lazily using the 9p backend.

Signed-off-by: Thomas Gazagnaire <thomas@gazagnaire.org>