### PR TITLE
ci: use the dev version of protocol-9p-unix to avoid End_of_file asyn…

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -16,6 +16,8 @@ RUN opam pin add irmin-http.1.2.0 -n https://github.com/mirage/irmin.git#81ffa25
 RUN opam pin add irmin-git.1.2.0 -n https://github.com/mirage/irmin.git#81ffa256d3aa6b73b689609f7a5ff01c298fe821
 RUN opam pin add irmin-unix.1.2.0 -n https://github.com/mirage/irmin.git#81ffa256d3aa6b73b689609f7a5ff01c298fe821
 
+RUN opam pin add protocol-9p-unix.dev --dev -n
+
 RUN opam depext -i asl win-eventlog camlzip alcotest mtime mirage-flow hvsock \
     git irmin irmin-unix lwt protocol-9p-unix tyxml redis multipart-form-data \
     pbkdf tls prometheus-app github git session irmin irmin-unix cmdliner \


### PR DESCRIPTION
…c exceptions

See https://github.com/mirage/ocaml-9p/pull/126

Signed-off-by: Thomas Gazagnaire <thomas@gazagnaire.org>