### PR TITLE
client 9p: build the mount helper in the right library

### DIFF
--- a/api/ocaml/9p/mount/jbuild
+++ b/api/ocaml/9p/mount/jbuild
@@ -3,7 +3,7 @@
 (executable
   ((name        mount)
    (public_name datakit-mount)
-   (package     datakit-client)
+   (package     datakit-client-9p)
    (libraries   (cmdliner unix))))
 
 ; TODO: generate the right version using tokpg watermarking


### PR DESCRIPTION
Signed-off-by: Thomas Gazagnaire <thomas@gazagnaire.org>