### PR TITLE
fix collection of build artefacts on Windows and OSX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-APP=Datakit.app
-EXE=Datakit
 PINOPTS=-y -k git
 
 BUILD=jbuilder build --dev
@@ -50,7 +48,7 @@ ci:
 
 clean:
 	rm -rf _build
-	rm -rf $(APP) $(EXE) _tests
+	rm -rf com.docker.db com.docker.db.exe COMMIT _tests
 	rm -f examples/ocaml-client/*.native
 	rm -f ci/skeleton/exampleCI.native
 	rm -f com.docker.db
@@ -62,15 +60,8 @@ bundle:
 	opam remove tls ssl -y
 	$(MAKE) clean
 	$(BUILD) src/datakit/bin/main.exe
-	mkdir -p $(APP)/Contents/MacOS/
-	mkdir -p $(APP)/Contents/Resources/lib/
-	cp _build/default/src/datakit/bin/main.exe $(APP)/Contents/MacOS/com.docker.db
+	cp _build/default/src/datakit/bin/main.exe com.docker.db
 	./scripts/check-dylib.sh
-	dylibbundler -od -b \
-	 -x $(APP)/Contents/MacOS/com.docker.db \
-	 -d $(APP)/Contents/Resources/lib \
-	 -p @executable_path/../Resources/lib
-	cp $(APP)/Contents/MacOS/com.docker.db .
 
 COMMIT:
 	@git rev-parse HEAD > COMMIT
@@ -79,9 +70,7 @@ exe:
 	opam remove tls ssl -y
 	rm -rf _build/
 	$(BUILD) src/datakit/bin/main.exe
-	mkdir -p $(EXE)
-	cp _build/debfault/src/datakit/bin/main.exe $(EXE)/datakit.exe
-	cp /usr/x86_64-w64-mingw32/sys-root/mingw/bin/zlib1.dll $(EXE)
+	cp _build/default/src/datakit/bin/main.exe com.docker.db.exe
 
 REPO=../opam-repository
 PACKAGES=$(REPO)/packages

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,3 +13,8 @@ install:
 
 build_script:
   - call %CYG_ROOT%\bin\bash.exe -l %APPVEYOR_BUILD_FOLDER%\appveyor-opam.sh
+  - call %CYG_ROOT%\bin\bash.exe -lc 'cd ${APPVEYOR_BUILD_FOLDER}; make exe COMMIT'
+
+artifacts:
+  - path: "com.docker.db.exe"
+  - path: "COMMIT"

--- a/circle.yml
+++ b/circle.yml
@@ -30,11 +30,8 @@ dependencies:
   - opam install depext && opam depext osx-fsevents datakit
   - opam list
   - opam reinstall datakit-server datakit -v
-  - opam config exec -- make COMMIT
   - mkdir -p _build/src/datakit
-  - opam config var bin
-  - opam config exec -- cp /Users/distiller/.opam/system/bin/datakit _build/src/datakit/main.native
-  - opam config exec -- make bundle
+  - opam config exec -- make bundle COMMIT
 test:
   override:
   - echo Dummy test

--- a/circle.yml
+++ b/circle.yml
@@ -15,7 +15,6 @@ dependencies:
   override:
   - brew update && brew upgrade
   - brew install wget ocaml opam dylibbundler
-  - if [ -e ~/.opam ] && ! [ -e ~/.opam/repo/config ]; then rm -rf ~/.opam; fi
   - opam init --comp system -n https://github.com/ocaml/opam-repository.git
   - opam switch system
   - opam pin add hvsock --dev -n

--- a/scripts/check-dylib.sh
+++ b/scripts/check-dylib.sh
@@ -3,15 +3,14 @@
 set -ue
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
-OUTPUT=${REPO_ROOT}/Datakit.app/Contents/MacOS/com.docker.db
+OUTPUT=${REPO_ROOT}/com.docker.db
 
-# The output should have 3 lines, e.g.:
+# The output should have 2 lines, e.g.:
 #
 # Datakit.app/Contents/MacOS/com.docker.db:
-#  /usr/lib/libz.1.dylib (compatibility version 1.0.0, current version 1.2.5)
 #  /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1213.0.0)
 
-if [ $(otool -L ${OUTPUT} | wc -l | xargs) != "3" ]; then
+if [ $(otool -L ${OUTPUT} | wc -l | xargs) != "2" ]; then
     otool -L ${OUTPUT}
     exit 1
 fi


### PR DESCRIPTION
/cc @guillaumerose You might need to update some paths to gather `com.docker.db` and `com.docker.db.exe`. Also note that `zlib` is not needed anymore (e.g. both binaries are now fully static).