### PR TITLE
Allow the GH bridge to run without a server (and use a local Git directly)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,4 @@
-FROM ocaml/opam-dev@sha256:64dc0522876ebbd27b186e3ba955ae5ab864ace580add5b0d1abb8715bdf1bbe
-RUN git -C /home/opam/opam-repository fetch origin && \
-    git -C /home/opam/opam-repository reset origin/master --hard && \
-    opam update -u
+FROM ocaml/opam-dev@sha256:1dd4440b3e5f182f705cb5a74f9d4e860c2842b45ed72c199de89a894d13f522
 #FROM ocaml/opam-dev:alpine-3.5_ocaml-4.04.0
 
 ENV OPAMERRLOGLEN=0 OPAMYES=1

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,9 +1,6 @@
-FROM ocaml/opam-dev@sha256:64dc0522876ebbd27b186e3ba955ae5ab864ace580add5b0d1abb8715bdf1bbe
-RUN git -C /home/opam/opam-repository fetch origin && \
-    git -C /home/opam/opam-repository reset origin/master --hard && \
-    git -C /home/opam/opam-repository rev-parse HEAD && \
-    opam update -u
+FROM ocaml/opam-dev@sha256:1dd4440b3e5f182f705cb5a74f9d4e860c2842b45ed72c199de89a894d13f522
 #FROM ocaml/opam-dev:alpine-3.5_ocaml-4.04.0
+
 ENV OPAMERRLOGLEN=0 OPAMYES=1
 RUN sudo apk add tzdata aspcud
 

--- a/Dockerfile.client
+++ b/Dockerfile.client
@@ -1,7 +1,4 @@
-FROM ocaml/opam-dev@sha256:64dc0522876ebbd27b186e3ba955ae5ab864ace580add5b0d1abb8715bdf1bbe
-RUN git -C /home/opam/opam-repository fetch origin && \
-    git -C /home/opam/opam-repository reset origin/master --hard && \
-    opam update -u
+FROM ocaml/opam-dev@sha256:1dd4440b3e5f182f705cb5a74f9d4e860c2842b45ed72c199de89a894d13f522
 #FROM ocaml/opam:alpine-3.5_ocaml-4.04.0
 
 ENV OPAMERRLOGLEN=0 OPAMYES=1

--- a/Dockerfile.github
+++ b/Dockerfile.github
@@ -1,8 +1,6 @@
-FROM ocaml/opam-dev@sha256:64dc0522876ebbd27b186e3ba955ae5ab864ace580add5b0d1abb8715bdf1bbe
-RUN git -C /home/opam/opam-repository fetch origin && \
-    git -C /home/opam/opam-repository reset origin/master --hard && \
-    opam update -u
+FROM ocaml/opam-dev@sha256:1dd4440b3e5f182f705cb5a74f9d4e860c2842b45ed72c199de89a894d13f522
 #FROM ocaml/opam-dev:alpine-3.5_ocaml-4.04.0
+
 ENV OPAMERRLOGLEN=0 OPAMYES=1
 RUN sudo apk add tzdata aspcud
 

--- a/Dockerfile.github
+++ b/Dockerfile.github
@@ -7,6 +7,7 @@ ENV OPAMERRLOGLEN=0 OPAMYES=1
 RUN sudo apk add tzdata aspcud
 
 RUN opam pin add git.dev --dev -n
+RUN opam pin add git-unix.dev -n --dev
 
 RUN opam pin add irmin.1.2.0 -n https://github.com/mirage/irmin.git#81ffa256d3aa6b73b689609f7a5ff01c298fe821
 RUN opam pin add irmin-mem.1.2.0 -n https://github.com/mirage/irmin.git#81ffa256d3aa6b73b689609f7a5ff01c298fe821
@@ -23,6 +24,7 @@ RUN opam config exec -- ocaml /tmp/check-libev.ml
 COPY datakit.opam /home/opam/src/datakit/datakit.opam
 COPY datakit-client.opam /home/opam/src/datakit/datakit-client.opam
 COPY datakit-client-9p.opam /home/opam/src/datakit/datakit-client-9p.opam
+COPY datakit-client-git.opam /home/opam/src/datakit/datakit-client-git.opam
 COPY datakit-server.opam /home/opam/src/datakit/datakit-server.opam
 COPY datakit-server-9p.opam /home/opam/src/datakit/datakit-server-9p.opam
 COPY datakit-github.opam /home/opam/src/datakit/datakit-github.opam
@@ -32,6 +34,7 @@ RUN opam pin add datakit.dev /home/opam/src/datakit -yn && \
     opam pin add datakit-server-9p.dev /home/opam/src/datakit -yn && \
     opam pin add datakit-client.dev /home/opam/src/datakit -yn && \
     opam pin add datakit-client-9p.dev /home/opam/src/datakit -yn && \
+    opam pin add datakit-client-git.dev /home/opam/src/datakit -yn && \
     opam pin add datakit-github.dev /home/opam/src/datakit -yn && \
     opam pin add datakit-bridge-github.dev /home/opam/src/datakit -yn
 

--- a/bridge/github/jbuild
+++ b/bridge/github/jbuild
@@ -13,6 +13,7 @@
   (package     datakit-bridge-github)
   (public_name datakit-bridge-github)
   (libraries   (datakit_bridge_github datakit-client-9p protocol-9p-unix
+                datakit-client-git
                 prometheus-app.unix datakit_log fmt.cli fmt.tty github.unix))))
 
 ; TODO: generate the right version using topkg watermarking

--- a/bridge/github/main.ml
+++ b/bridge/github/main.ml
@@ -8,7 +8,14 @@ module Log = (val Logs.src_log src : Logs.LOG)
 let src9p = Logs.Src.create "g9p" ~doc:"Github bridge for Datakit (9p)"
 module Log9p = (val Logs.src_log src9p : Logs.LOG)
 
-let jar_path = "/run/secrets"
+let jar_paths = [
+  (try Sys.getenv "HOME" with Not_found -> "") ^ "/.github/jar";
+  "/run/secrets";
+]
+
+let jar_path =
+  try List.find Sys.file_exists jar_paths
+  with Not_found -> List.hd jar_paths
 
 let quiet_9p () =
   Logs.Src.set_level src9p (Some Logs.Info);

--- a/datakit-bridge-github.opam
+++ b/datakit-bridge-github.opam
@@ -17,6 +17,7 @@ depends: [
   "lwt" {>= "3.0.0"}
   "datakit-github"    {>= "0.11.0"}
   "datakit-client-9p" {>= "0.11.0"}
+  "datakit-client-git"
   "logs" "fmt"
   "mtime" {>= "1.0.0"}
   "asl" "win-eventlog"


### PR DESCRIPTION
For instance, you could do:

```
$ datakit-bridge-github -r samoht/test -d git:///tmp/foo
Starting datakit-bridge-github %%VERSION%% (*:rw)...
Connecting to git:///tmp/foo [github-metadata].
```

And then:

```
$ tree /tmp/foo
.
└── samoht
    └── test
        ├── pr
        │   └── 32
        │       ├── base
        │       ├── head
        │       ├── state
        │       └── title
        └── ref
            ├── heads
            │   ├── adassad
            │   │   └── head
            │   ├── bar
            │   │   └── head
            │   ├── master
            │   │   └── head
            │   ├── samoht-patch-1
            │   │   └── head
            │   ├── test
            │   │   └── head
            │   ├── test2
            │   │   └── head
            │   ├── toto
            │   │   └── head
            │   └── yyy
            │       └── head
            └── tags
                └── titi
                    └── head

16 directories, 13 files
```

You can then edit the Git repo, and when you commit changes they are reflected directly to GitHub.