### PR TITLE
Simplify the creation of DataKit stores using an Irmin backend

### DIFF
--- a/src/datakit/datakit.ml
+++ b/src/datakit/datakit.ml
@@ -22,6 +22,8 @@ module type S = Store.S
 module type GIT_S_MAKER = Store.GIT_S_MAKER
 module Make_git = Store.Make_git
 
+module Make (M: Irmin.S_MAKER) = M (Metadata)(Blob)(Path)(Branch)(Hash)
+
 module type VFS = sig
   type repo
   val create: info:(string -> Irmin.Info.t) -> repo -> Vfs.Dir.t

--- a/src/datakit/datakit.mli
+++ b/src/datakit/datakit.mli
@@ -100,6 +100,9 @@ module type S = Irmin.S
    and type Tree.Hash.t = hash
    and type Contents.Hash.t = hash
 
+(** Make an DataKit store from a normal Irmin backend. *)
+module Make (M: Irmin.S_MAKER): S
+
 (** Similar to [Irmin_git.S_MAKER] *)
 module type GIT_S_MAKER =
   functor (C: Irmin.Contents.S) ->


### PR DESCRIPTION
@nickbetteridge with f2ccec895786a44d1678dac085ab60a82b6f4d28 you should be able to write:

```ocaml
module Store = Datakit.Make(Make)
```

where `Make` is your Irmin backend. Thanks again for your report, it helped a lot to clarify the API.