### PR TITLE
github: add a `owner` file to identify the PR creator

### DIFF
--- a/bridge/github/datakit_github_api.ml
+++ b/bridge/github/datakit_github_api.ml
@@ -81,7 +81,8 @@ module PR = struct
     let state = pr.pull_state in
     let title = pr.pull_title in
     let base = pr.pull_base.branch_ref in
-    PR.v ~state ~title ~base head pr.pull_number
+    let owner = pr.pull_user.user_login in
+    PR.v ~state ~title ~base ~owner head pr.pull_number
 
   let to_gh pr = {
     update_pull_title = Some pr.title;
@@ -97,7 +98,8 @@ module PR = struct
     let title = pr.pull_request_event_pull_request.pull_title in
     let base = pr.pull_request_event_pull_request.pull_base.branch_ref in
     let number = pr.pull_request_event_number in
-    PR.v ~state ~title ~base head number
+    let owner = pr.pull_request_event_pull_request.pull_user.user_login in
+    PR.v ~state ~title ~base ~owner head number
 
 end
 

--- a/ci/tests/test_utils.ml
+++ b/ci/tests/test_utils.ml
@@ -189,6 +189,7 @@ let update_pr hooks ~id ~head ~states ~message =
   update hooks ~message (
     (Printf.sprintf "user/project/pr/%d/head" id, head) ::
     (Printf.sprintf "user/project/pr/%d/state" id, "open") ::
+    (Printf.sprintf "user/project/pr/%d/owner" id, "joe") ::
     List.map (fun (path, data) -> Printf.sprintf "user/project/commit/%s/status/%s" head path, data) states
   )
 

--- a/src/datakit-github/datakit_github.ml
+++ b/src/datakit-github/datakit_github.ml
@@ -164,10 +164,12 @@ module PR = struct
     state: [`Open | `Closed];
     title: string;
     base: string;
+    owner: string;
   }
 
-  let v ?(state=`Open) ~title ?(base="master") head number =
-    { state; title = String.trim title; base = String.trim base; head; number }
+  let v ?(state=`Open) ~title ?(base="master") ~owner head number =
+    { state; title = String.trim title; base = String.trim base; head;
+      number; owner }
 
   type id = Repo.t * int
 
@@ -192,6 +194,7 @@ module PR = struct
   let compare_num x y = Pervasives.compare x.number y.number
   let number t = t.number
   let title t = t.title
+  let owner t = t.owner
   let state t = t.state
   let close t = { t with state = `Closed }
   let same_id x y = repo x = repo y && number x = number y
@@ -203,8 +206,9 @@ module PR = struct
     ]
 
   let pp ppf t =
-    Fmt.pf ppf "{%a %d[%s] %s %a %S}"
-      Repo.pp (repo t) t.number (commit_hash t) t.base pp_state t.state t.title
+    Fmt.pf ppf "{%a %d[%s] %s %s %a %S}"
+      Repo.pp (repo t) t.number (commit_hash t) t.base t.owner pp_state
+      t.state t.title
 
   let pp_id ppf (r, n) = Fmt.pf ppf "{%a %d}" Repo.pp r n
 

--- a/src/datakit-github/datakit_github.mli
+++ b/src/datakit-github/datakit_github.mli
@@ -117,13 +117,14 @@ module PR: sig
     state: [`Open | `Closed];
     title: string;
     base: string;
+    owner: string;
   }
 
-  val v: ?state:[`Open|`Closed] -> title:string -> ?base:string ->
-    Commit.t -> int -> t
-  (** [v c n ~title] is the pull-request [n] with head commit [c] and
-      title [title]. If [base] is not set, use ["master"]. If [state]
-      is not set, use [`Open]. *)
+  val v: ?state:[`Open|`Closed] -> title:string -> ?base:string -> owner:string
+    -> Commit.t -> int -> t
+  (** [v c n ~title ~owner] is the pull-request [n] with head commit
+      [c], title [title] and owner [owner]. If [base] is not set, use
+      ["master"]. If [state] is not set, use [`Open]. *)
 
   val pp: t Fmt.t
   (** [pp] is the pretty-printer for pull-request values. *)
@@ -168,6 +169,9 @@ module PR: sig
 
   val title: t -> string
   (** [title t] is [t]'s title. *)
+
+  val owner: t -> string
+  (** [owner t] is [t]'s owner. *)
 
   val same_id: t -> t -> bool
   (** [same_id x y] is true if [x] and [y] have the same ID. *)


### PR DESCRIPTION
This file contains the GitHub login of the user having opened the PR.

Fix #586 

Signed-off-by: Thomas Gazagnaire <thomas@gazagnaire.org>