### PR TITLE
Fix build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PINOPTS=-y -k git
+PINOPTS=-yn -k git
 
 BUILD=jbuilder build --dev
 RUNTEST=jbuilder runtest
@@ -9,13 +9,28 @@ all:
 	$(BUILD)
 
 depends:
-	opam pin add ${PINOPTS} datakit-client .
-	opam pin add ${PINOPTS} datakit-server .
-	opam pin add ${PINOPTS} datakit .
-	opam pin add ${PINOPTS} datakit-github .
-	opam pin add ${PINOPTS} datakit-bridge-github .
-	opam pin add ${PINOPTS} datakit-bridge-local-git .
-	opam pin add ${PINOPTS} datakit-ci .
+	opam pin add ${PINOPTS} datakit-client.dev .
+	opam pin add ${PINOPTS} datakit-server.dev .
+	opam pin add ${PINOPTS} datakit-client-9p.dev .
+	opam pin add ${PINOPTS} datakit-server-9p.dev .
+	opam pin add ${PINOPTS} datakit.dev .
+	opam pin add ${PINOPTS} datakit-github.dev .
+	opam pin add ${PINOPTS} datakit-bridge-github.dev .
+	opam pin add ${PINOPTS} datakit-bridge-local-git.dev .
+	opam pin add ${PINOPTS} datakit-ci.dev .
+	opam pin add git.dev --dev -ny
+	opam pin add git-http.dev --dev -ny
+	opam pin add git-mirage.dev --dev -ny
+	opam pin add git-unix.dev --dev -ny
+	opam pin add irmin.dev --dev -ny
+	opam pin add irmin-fs.dev https://github.com/mirage/irmin.git -ny
+	opam pin add irmin-mem.dev https://github.com/mirage/irmin.git -ny
+	opam pin add irmin-git.dev --dev -ny
+	opam pin add irmin-http.dev --dev -ny
+	opam pin add irmin-mirage.dev --dev -ny
+	opam pin add irmin-fs.dev --dev -ny
+	opam pin add irmin-unix.dev --dev -ny
+	opam install -y --deps-only datakit-ci datakit datakit-bridge-github datakit-bridge-local-git
 	opam update -u datakit datakit-client datakit-server datakit-github \
 	  datakit-ci datakit-bridge-github datakit-bridge-local-git -y
 

--- a/datakit-client.opam
+++ b/datakit-client.opam
@@ -15,5 +15,6 @@ depends: [
   "astring"
   "result"
   "fmt"
+  "lwt"
   "cstruct" {> "2.2.0"}
 ]


### PR DESCRIPTION
On a clean system, building failed with:

```
# Error: External library "lwt" not found.
```