### PR TITLE
sync PR's comments

### DIFF
--- a/src/datakit-github/datakit_github.mli
+++ b/src/datakit-github/datakit_github.mli
@@ -130,6 +130,33 @@ module Commit: sig
 
 end
 
+module Comment: sig
+
+  (** The type for comments. *)
+  type t = private {
+    id  : int;
+    user: User.t;
+    body: string;
+  }
+
+  val v: id:int -> user:User.t -> body:string -> t
+  (** [v ~id ~user ~body] is a comment done by [user] saying [body]. *)
+
+  val id: t -> int
+  (** [id t] is [t]'s ID, e.g. the appearance order in the comment
+      list. *)
+
+  val user: t -> User.t
+  (** [user t] is [t]'s user. *)
+
+  val body: t -> string
+  (** [body t] is [t]'s body. *)
+
+  val pp: t Fmt.t
+  (** [pp] is the pretty-printer for comments. *)
+
+end
+
 module PR: sig
 
   (** The type for pull-requests values. *)
@@ -140,10 +167,11 @@ module PR: sig
     title: string;
     base: string;
     owner: string;
+    comments: Comment.t array;
   }
 
-  val v: ?state:[`Open|`Closed] -> title:string -> ?base:string -> owner:string
-    -> Commit.t -> int -> t
+  val v: ?state:[`Open|`Closed] -> title:string -> ?base:string ->
+    owner:string -> comments:Comment.t array -> Commit.t -> int -> t
   (** [v c n ~title ~owner] is the pull-request [n] with head commit
       [c], title [title] and owner [owner]. If [base] is not set, use
       ["master"]. If [state] is not set, use [`Open]. *)
@@ -194,6 +222,9 @@ module PR: sig
 
   val owner: t -> string
   (** [owner t] is [t]'s owner. *)
+
+  val comments: t -> Comment.t array
+  (** [comments t] are [t]'s comments. *)
 
   val same_id: t -> t -> bool
   (** [same_id x y] is true if [x] and [y] have the same ID. *)


### PR DESCRIPTION
### Feature

The goal is to expose PR's comments in the DataKit API, so DataKit CI can use it to implement something similar to https://wiki.jenkins-ci.org/display/JENKINS/GitHub+pull+request+builder+plugin /cc @dave-tucker who needs this the [LinuxKit](https://github.com/linuxkit/linuxkit)'s CI.

An example on how to use this:

```
$ jbuilder exec -- datakit-bridge-github -d git:///tmp/foo -r samoht/test
Starting datakit-bridge-github %%VERSION%% (*:rw)...
Connecting to git:///tmp/foo [github-metadata].
[ ... wait 1s and CTRL^C ... ] 

$ cat /tmp/foo/samoht/test/pr/32/comments/0/body
This is a test!

$ tree /tmp/foo/samoht/test/pr/32/
/tmp/foo/samoht/test/pr/32/
├── base
├── comments
│   ├── 0
│   │   ├── body
│   │   ├── id
│   │   └── user
│   └── 1
│       ├── body
│       ├── id
│       └── user
├── head
├── owner
├── state
└── title
```

### Status

One-way sync (from GitHub to DataKit) are working.

### Limitatations

DataKit-to-GitHub sync is not yet working but all the infrastructure is in place.

We need to be careful with the added extra startup time, as more files/directories means more 9p messages which might add quite a bit of lags on startup. I'll make some measurement before enabling that feature, but 9p is supposed to disappear soon and we don't restart the CI server very often, so that's not a bloquer. 

Feedback is welcome.