### PR TITLE
build: support jbuilder workspaces

### DIFF
--- a/api/ocaml/9p/mount/jbuild
+++ b/api/ocaml/9p/mount/jbuild
@@ -9,5 +9,5 @@
 ; TODO: generate the right version using tokpg watermarking
 (rule
   ((targets (version.ml))
-   (deps    (${ROOT}/src/version.ml))
+   (deps    (../../../../src/version.ml))
    (action  (copy ${<} ${@}))))

--- a/bridge/github/jbuild
+++ b/bridge/github/jbuild
@@ -19,5 +19,5 @@
 ; TODO: generate the right version using topkg watermarking
 (rule
   ((targets (version.ml))
-   (deps    (${ROOT}/src/version.ml))
+   (deps    (../../src/version.ml))
    (action  (copy ${<} ${@}))))


### PR DESCRIPTION
remove use of ${ROOT} and use relative path referencing, which
in turn allows datakit to be built as part of a bigger jbuilder
workspace.

This can be tested by cloning this repository into a subdir
and running `jbuilder build` in the top-level directory.

Signed-off-by: Anil Madhavapeddy <anil@docker.com>