### PR TITLE
Go: improve transaction API

### DIFF
--- a/api/go-datakit/client.go
+++ b/api/go-datakit/client.go
@@ -148,14 +148,16 @@ func (c *Client) Remove(ctx context.Context, path ...string) error {
 	if err != nil {
 		return err
 	}
-	defer c.freeFid(ctx, fid)
 	if _, err := c.session.Walk(ctx, fid, fid, path...); err != nil {
 		if err == enoent || err == enotdir {
+			c.freeFid(ctx, fid)
 			return nil
 		}
 		log.Println("Failed to walk to", path, err)
+		c.freeFid(ctx, fid)
 		return err
 	}
+	// Remove will cluck the fid, even if it fails
 	if err := c.session.Remove(ctx, fid); err != nil {
 		if err == enoent {
 			return nil

--- a/api/go-datakit/config.go
+++ b/api/go-datakit/config.go
@@ -265,10 +265,6 @@ func (f *Record) StringRefField(key string, value *string) *StringRefField {
 		if err != nil {
 			log.Fatalf("Failed to create transaction for updating state branch: %#v", err)
 		}
-		existingValue, err := t.Read(ctx, append(f.path, path...))
-		if (newValue == nil && err != nil) || (newValue != nil && *newValue == existingValue && err == nil) {
-			return
-		}
 		if newValue != nil {
 			if err = t.Write(ctx, append(f.path, path...), *newValue); err != nil {
 				log.Fatalf("Failed to write state %#v = %s: %#v", path, newValue, err)

--- a/api/go-datakit/config_test.go
+++ b/api/go-datakit/config_test.go
@@ -157,7 +157,7 @@ func TestChangeDefaults(t *testing.T) {
 }
 
 func write(ctx context.Context, client *Client, path []string, value string) error {
-	t, err := NewTransaction(ctx, client, "master", "test-tmp")
+	t, err := NewTransaction(ctx, client, "master")
 
 	if err != nil {
 		return err
@@ -175,7 +175,7 @@ func write(ctx context.Context, client *Client, path []string, value string) err
 }
 
 func rm(ctx context.Context, client *Client, branch string, path []string) error {
-	t, err := NewTransaction(ctx, client, branch, "test-tmp")
+	t, err := NewTransaction(ctx, client, branch)
 
 	if err != nil {
 		return err

--- a/api/go-datakit/snapshot_test.go
+++ b/api/go-datakit/snapshot_test.go
@@ -16,7 +16,7 @@ func TestSnapshot(t *testing.T) {
 		t.Fatalf("Failed to connect to db: %v", err)
 	}
 
-	trans, err := NewTransaction(ctx, client, "master", "test-tmp")
+	trans, err := NewTransaction(ctx, client, "master")
 
 	if err != nil {
 		t.Fatalf("NewTransaction failed: %v", err)

--- a/api/go-datakit/transaction.go
+++ b/api/go-datakit/transaction.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"io"
 	"log"
+	"strconv"
+	"sync/atomic"
 
 	p9p "github.com/docker/go-p9p"
 	"context"
@@ -15,10 +17,14 @@ type transaction struct {
 	newBranch  string
 }
 
+var nextTransaction = int64(0)
+
 // NewTransaction opens a new transaction originating from fromBranch, named
 // newBranch.
-func NewTransaction(ctx context.Context, client *Client, fromBranch string, newBranch string) (*transaction, error) {
+func NewTransaction(ctx context.Context, client *Client, fromBranch string) (*transaction, error) {
 
+	id := atomic.AddInt64(&nextTransaction, 1)
+	newBranch := strconv.FormatInt(id, 10)
 	err := client.Mkdir(ctx, "branch", fromBranch)
 	if err != nil {
 		log.Println("Failed to Create branch/", fromBranch, err)

--- a/api/go-datakit/transaction_test.go
+++ b/api/go-datakit/transaction_test.go
@@ -15,7 +15,7 @@ func TestTransaction(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to connect to db: %v", err)
 	}
-	trans, err := NewTransaction(ctx, client, "master", "test-tmp")
+	trans, err := NewTransaction(ctx, client, "master")
 
 	if err != nil {
 		t.Fatalf("NewTransaction failed: %v", err)


### PR DESCRIPTION
Don't invite clients to name the temporary branch: they'll accidentally use non-unique strings which will cause problems when 2 Goroutines try to share the same branch name

Minor fixes:
- fix one transaction leak
- fix one clunk error
