### PR TITLE
[WIP] Update to latest alcotest, conduit, cohttp, github-hooks and session

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ ci:
 	$(RUNTEST) ci/tests
 
 clean:
-	rm -rf _build
+	jbuilder clean
 	rm -rf com.docker.db com.docker.db.exe COMMIT _tests
 	rm -f examples/ocaml-client/*.native
 	rm -f ci/skeleton/exampleCI.native

--- a/bridge/github/jbuild
+++ b/bridge/github/jbuild
@@ -3,8 +3,8 @@
 (library
  ((name      datakit_bridge_github)
   (wrapped   false)
-  (modules   (:standard \ main \ version))
-  (libraries (rresult github-hooks.unix github.unix datakit-github
+  (modules   ((:standard \ main) \ version))
+  (libraries (rresult github-hooks-unix github.unix datakit-github
               datakit-client))))
 
 (executable
@@ -13,11 +13,11 @@
   (package     datakit-bridge-github)
   (public_name datakit-bridge-github)
   (libraries   (datakit_bridge_github datakit-client-9p protocol-9p-unix
-                datakit-client-git
+                datakit-client-git logs.cli
                 prometheus-app.unix datakit_log fmt.cli fmt.tty github.unix))))
 
 ; TODO: generate the right version using topkg watermarking
-(rule
+ (rule
   ((targets (version.ml))
    (deps    (../../src/version.ml))
    (action  (copy ${<} ${@}))))

--- a/ci/src/jbuild
+++ b/ci/src/jbuild
@@ -5,10 +5,10 @@
   (public_name datakit-ci)
   (wrapped     false)
   (libraries   (datakit-github datakit-client datakit-client-9p
-                yojson cmdliner tyxml multipart-form-data
+                yojson cmdliner tyxml multipart-form-data conduit-lwt-unix
                 prometheus-app.unix webmachine redis-lwt session pbkdf
-                github protocol-9p-unix logs.cli session.redis-lwt
-                session.webmachine github.unix fmt.cli fmt.tty))
+                github protocol-9p-unix logs.cli session-redis-lwt
+                session-webmachine github.unix fmt.cli fmt.tty))
   (preprocess  (per_module
                  ((pps (ppx_sexp_conv)) (cI_secrets cI_web_utils))))
  ))

--- a/datakit-bridge-github.opam
+++ b/datakit-bridge-github.opam
@@ -27,8 +27,8 @@ depends: [
   "prometheus-app"
   "protocol-9p-unix" {>= "0.11.0"}
   "datakit-client" {>= "0.10.0"}
-  "github-hooks" {>= "0.1.1"}
+  "github-hooks-unix" {>= "0.2.0"}
   "github" {>= "2.1.0"}
-  "alcotest" {test}
+  "alcotest" {test & >= "0.8.0"}
   "datakit"  {test & >= "0.11.0"}
 ]

--- a/datakit-ci.opam
+++ b/datakit-ci.opam
@@ -24,11 +24,12 @@ depends: [
   "logs"
   "tyxml" {>= "4.0.0"}
   "tls"
-  "conduit"
+  "conduit-lwt-unix"
   "io-page"
   "pbkdf"
   "webmachine" {>= "0.4.0"}
-  "session" {>= "0.3.0"}
+  "session-redis-lwt" {>= "0.4.0"}
+  "session-webmachine" {>= "0.4.0"}
   "redis-lwt"
   "asetmap"
   "github" {>= "2.2.0"}
@@ -38,6 +39,6 @@ depends: [
   "crunch" {build}
   "datakit" {test & >= "0.11.0"}
   "irmin-unix" {test & >= "1.2.0"}
-  "alcotest" {test}
+  "alcotest" {test & >= "0.8.0"}
 ]
 available: [ocaml-version >= "4.03.0"]

--- a/datakit-client-git.opam
+++ b/datakit-client-git.opam
@@ -17,7 +17,7 @@ depends: [
   "irmin-git" {>= "1.2.0"}
   "irmin-watcher"
   "git-unix"
-  "alcotest"  {test}
+  "alcotest"  {test & >= "0.8.0"}
   "irmin-mem" {test}
   "irmin-git" {test}
 ]

--- a/datakit.opam
+++ b/datakit.opam
@@ -26,7 +26,8 @@ depends: [
   "cstruct"     {>= "2.2"}
   "result"
   "lwt"         {>= "3.0.0"}
-  "conduit" "mirage-flow"
+  "conduit-lwt-unix"
+  "mirage-flow"
   "named-pipe"  {>= "0.4.0"}
   "hvsock"      {>= "0.8.1"}
   "logs"        {>= "0.5.0"}
@@ -38,6 +39,6 @@ depends: [
   "protocol-9p-unix"  {>= "0.11.0"}
   "datakit-server-9p" {>= "0.11.0"}
   "datakit-client-9p" {test & >= "0.11.0"}
-  "alcotest"          {test & >= "0.7.0"}
+  "alcotest"          {test & >= "0.8.0"}
 ]
 available: [ocaml-version >= "4.02.0"]

--- a/src/datakit-io/jbuild
+++ b/src/datakit-io/jbuild
@@ -3,4 +3,4 @@
 (library
  ((name        datakit_io)
   (wrapped     false)
-  (libraries   (irmin-git conduit.lwt-unix))))
+  (libraries   (irmin-git conduit-lwt-unix))))

--- a/src/datakit-log/jbuild
+++ b/src/datakit-log/jbuild
@@ -3,5 +3,5 @@
 (library
  ((name        datakit_log)
   (wrapped     false)
-  (libraries   (cmdliner fmt logs.cli prometheus-app.unix mtime mtime.clock.os
+  (libraries   (cmdliner fmt logs.fmt prometheus-app.unix mtime mtime.clock.os
                 win-eventlog asl))))

--- a/src/datakit/bin/jbuild
+++ b/src/datakit/bin/jbuild
@@ -5,7 +5,7 @@
   (package     datakit)
   (public_name datakit)
   (libraries   (datakit_io datakit datakit_conduit datakit_log
-                cmdliner fmt.cli fmt.tty logs.fmt asetmap git irmin
+                cmdliner fmt.cli fmt.tty logs.cli asetmap git irmin
                 irmin-git irmin-watcher))
  ))
 

--- a/tests/common/test_client.mli
+++ b/tests/common/test_client.mli
@@ -4,5 +4,5 @@ module type S = sig
 end
 
 module Make (DK: S): sig
-  val test_set : Alcotest.test_case list
+  val test_set : unit Alcotest.test_case list
 end


### PR DESCRIPTION
This needs a bunch of not yet released packages:
- github-hooks.0.2.0 and github-hooks-unix.0.2.0: https://github.com/dsheets/ocaml-github-hooks/pull/12 /cc @dsheets
- session-redis-lwt.0.4.0 and session-webmachine.0.4.0: https://github.com/inhabitedtype/ocaml-session/pull/16 /cc @seliopou

I still need to update the Dockerfiles and CI scripts to pins these versions.
