### PR TITLE
fmt.tty is used by datakit-log

### DIFF
--- a/src/datakit-log/jbuild
+++ b/src/datakit-log/jbuild
@@ -4,4 +4,4 @@
  ((name        datakit_log)
   (wrapped     false)
   (libraries   (cmdliner fmt logs.cli prometheus-app.unix mtime mtime.clock.os
-                win-eventlog asl logs.fmt))))
+                win-eventlog asl logs.fmt fmt.tty))))


### PR DESCRIPTION
This will fix compatibility with jbuilder beta 18.