### PR TITLE
ci: add support for Docker parameter 'network'

### DIFF
--- a/ci/src/cI_docker.mli
+++ b/ci/src/cI_docker.mli
@@ -14,5 +14,5 @@ val build : t -> ?from:Image.t -> CI_git.commit -> Image.t CI_term.t
 type command
 val command :
   logs:CI_live_log.manager -> pool:CI_monitored_pool.t -> timeout:float ->
-  label:string -> ?entrypoint:string -> ?user:string -> string list -> command
+  label:string -> ?entrypoint:string -> ?user:string -> ?network:string -> string list -> command
 val run : command -> Image.t -> unit CI_term.t

--- a/ci/src/datakit_ci.mli
+++ b/ci/src/datakit_ci.mli
@@ -556,7 +556,7 @@ module Docker : sig
 
   val command :
     logs:Live_log.manager -> pool:Monitored_pool.t -> timeout:float ->
-    label:string -> ?entrypoint:string -> ?user:string -> string list -> command
+    label:string -> ?entrypoint:string -> ?user:string -> ?network:string -> string list -> command
   (** [create ~logs ~pool ~timeout ~label args] is a cache of Docker run results. *)
 
   val run : command -> Image.t -> unit Term.t


### PR DESCRIPTION
Specify `--network` argument for docker run. Example usage:

```ocaml
(Docker.run (Docker.command ~logs ~pool ~timeout:(30. *. minute) ~label:"my_label" ~network:"host" []) image)
```

Fixes #623.

Signed-off-by: Péter Garamvölgyi <peter.garamvolgyi@hotmail.com>