### PR TITLE
[Tracking] self-ci: configure for new hosting

### DIFF
--- a/ci/self-ci/datakit-ci.yml
+++ b/ci/self-ci/datakit-ci.yml
@@ -2,7 +2,7 @@ version: '3.1'
 
 services:
   bridge:
-    command: '--listen-prometheus=9090 --datakit tcp://datakit:5640 -v -c "*:r,status[ci/datakit]:x,webhook:rw" --webhook http://hooks.datakit.ci:81 --log-destination timestamp'
+    command: '--listen-prometheus=9090 --datakit tcp://datakit:5640 -v -c "*:r,status[ci/datakit]:x,webhook:rw" --webhook http://35.187.94.83:81 --log-destination timestamp'
     image: 'datakit/github-bridge'
     ports:
       - '81:81'


### PR DESCRIPTION
Docker Cloud is being shut down, so move to GCP.

Might not need this once DNS is updated, but this is the config we're running with right now.