### PR TITLE
Add support for the latest Atd 2.0 JSON adapters

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+### 0.12.2
+
+- Support the latest GitHub and Atd bindings (>=2.0.0) (@avsm)
+
 ### 0.12.1 (2018-01-23)
 
 - Upgrade to Tls >= 0.9.0 and Cohttp-lwt-unix >= 1.0.0 (#615, @jpdeplaix)

--- a/bridge/github/datakit_github_api.ml
+++ b/bridge/github/datakit_github_api.ml
@@ -149,7 +149,7 @@ module Status = struct
     | l           -> Some (String.concat ~sep:"/" l)
 
   let of_gh_state = function
-    | `Unknown (s, _) -> failwith ("unknown: " ^ s)
+    | `Unknown s -> failwith ("unknown: " ^ s)
     | #Status_state.t as s -> s
 
   let to_gh_state s = (s :> Github_t.status_state)

--- a/datakit.opam
+++ b/datakit.opam
@@ -20,7 +20,7 @@ depends: [
   "rresult" "astring" "fmt" "asetmap"
   "git"         {>= "1.11.5"}
   "uri"
-  "irmin"       {>= "1.2.0"}
+  "irmin"       {>= "1.2.0" & <"1.4.0"}
   "irmin-mem"   {>= "1.2.0"}
   "irmin-git"   {>= "1.2.0"}
   "cstruct"     {>= "2.2"}

--- a/src/datakit-conduit/jbuild
+++ b/src/datakit-conduit/jbuild
@@ -4,4 +4,4 @@
  ((name      datakit_conduit)
   (wrapped   false)
   (libraries (uri fmt lwt astring protocol-9p-unix hvsock.lwt-unix
-              datakit-server-9p))))
+              datakit-server-9p named-pipe.lwt))))


### PR DESCRIPTION
These have a new interface for handling unknown tags, which changes
the polymorphic variant interface in the github bridge in datakit.

This also fixes the build by adding a constraint on Irmin which
has changed how it hashes, and explicitly depending on named-pipe.lwt

This PR depends on `opam pin github --dev`