### PR TITLE
fix 32bit build

### DIFF
--- a/api/go-datakit/client.go
+++ b/api/go-datakit/client.go
@@ -2,13 +2,13 @@ package datakit
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"log"
 	"net"
 	"sync"
 
 	p9p "github.com/docker/go-p9p"
-	"context"
 )
 
 type Client struct {
@@ -27,7 +27,7 @@ var rwx = p9p.DMREAD | p9p.DMWRITE | p9p.DMEXEC
 var rx = p9p.DMREAD | p9p.DMEXEC
 var rw = p9p.DMREAD | p9p.DMWRITE
 var r = p9p.DMREAD
-var dirperm = uint32(rwx<<6 | rx<<3 | rx | p9p.DMDIR)
+var dirperm = uint32(rwx<<6|rx<<3|rx) | p9p.DMDIR
 var fileperm = uint32(rw<<6 | r<<3 | r)
 
 // Dial opens a connection to a 9P server


### PR DESCRIPTION
The value of `p9p.DMDIR` overflows 32bit signed int so cast it before usage to support building on arm.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>