### PR TITLE
datakit/ci: adapt to crunch 3.0.0

### DIFF
--- a/ci/src/cI_static.mli
+++ b/ci/src/cI_static.mli
@@ -2,4 +2,3 @@ val read : string -> string option
 
 (* to avoid warning 32 *)
 val file_list: string list
-val size: string -> int64 option


### PR DESCRIPTION
crunch 3.0.0 removes the `size`, which is included here only to silence warning 32. crunch 3.0.0 is PR'ed to opam-repository https://github.com/ocaml/opam-repository/pull/13549