### PR TITLE
support the webmachine 0.6.0+ interface

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 - ci: Add missing dependency on Base64 and port to >=3.0.0 interface (#642 @avsm)
 - ci: Adapt to crunch.3.0.0 interface (#641 @hannesm)
 - ci: Use non-deprecated Yojson types in 1.7.0 and higher (#642 @avsm)
+- Support the WebMachine 0.6.0+ interface (@avsm)
 
 ### 0.12.2 (2019-01-18)
 

--- a/ci/src/cI_web_utils.ml
+++ b/ci/src/cI_web_utils.ml
@@ -49,7 +49,10 @@ end
 
 module Wm = struct
   module Rd = Webmachine.Rd
-  include Webmachine.Make(Cohttp_lwt_unix.IO)
+  module UnixClock = struct
+    let now = fun () -> int_of_float (Unix.gettimeofday ())
+  end
+  include Webmachine.Make(Cohttp_lwt_unix.IO)(UnixClock)
 end
 module Session = struct
   module Memory = Session.Lift.IO(Lwt)(Session.Memory)

--- a/datakit-ci.opam
+++ b/datakit-ci.opam
@@ -24,7 +24,7 @@ depends: [
   "conduit-lwt-unix" {>= "1.0.0"}
   "io-page"
   "pbkdf"
-  "webmachine" {>= "0.4.0"}
+  "webmachine" {>= "0.6.0"}
   "session-redis-lwt" {>= "0.4.0"}
   "session-webmachine" {>= "0.4.0"}
   "redis-lwt"


### PR DESCRIPTION
This however conflicts with irmin-http, which requires webmachine<0.6.0.

So this PR is a draft until Irmin 2.0.0 is released which has a newer irmin-http.
Unless we can cut a minor release of irmin-http from the 1.x branch @samoht?